### PR TITLE
Sync api keys with a redis instance

### DIFF
--- a/api_keys/tests.py
+++ b/api_keys/tests.py
@@ -1,38 +1,62 @@
+from mock import patch
+from mockredis import mock_strict_redis_client
+
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 
 from account.signals import user_signed_up
 
 from .models import APIKey, create_key_for_new_user
+from .utils import redis_connection
 
 
-class SignalsTest(TestCase):
+class PatchedRedisTestCase(TestCase):
+    """
+    Helper TestCase subclass that patches the redis library.
+    """
 
     def setUp(self):
+        self.redis_patcher = patch('api_keys.utils.redis.StrictRedis', mock_strict_redis_client)
+        self.redis_patcher.start()
+
+    def tearDown(self):
+        self.redis_patcher.stop()
+
+
+class SignalsTest(PatchedRedisTestCase):
+
+    def setUp(self):
+        super(SignalsTest, self).setUp()
         self.user = User.objects.create_user("Test user", "test@example.com", "password")
 
     def tearDown(self):
+        super(SignalsTest, self).tearDown()
         self.user.delete()
 
     def test_creates_key_when_user_signs_up(self):
         self.assertFalse(APIKey.objects.filter(user=self.user).exists())
         user_signed_up.send(self.__class__, user=self.user, form={})
         self.assertTrue(APIKey.objects.filter(user=self.user).exists())
+        APIKey.objects.get(user=self.user).delete()
 
     def test_deletes_existing_key(self):
         key = APIKey.objects.create(user=self.user, key=APIKey.generate_key())
         create_key_for_new_user(self.user, form={})
         self.assertNotEqual(key, APIKey.objects.get(user=self.user))
+        key.delete()
 
 
-class APIKeyDetailViewTest(TestCase):
+class APIKeyDetailViewTest(PatchedRedisTestCase):
 
     def setUp(self):
+        super(APIKeyDetailViewTest, self).setUp()
         self.user = User.objects.create_user("Test user", "test@example.com", "password")
         self.key = APIKey.objects.create(user=self.user, key=APIKey.generate_key())
 
     def tearDown(self):
+        super(APIKeyDetailViewTest, self).tearDown()
         self.user.delete()
         self.key.delete()
 
@@ -51,3 +75,51 @@ class APIKeyDetailViewTest(TestCase):
         self.client.login(username="Test user", password="password")
         response = self.client.get(url)
         self.assertContains(response, self.key.key)
+
+
+class APIKeyModelTest(PatchedRedisTestCase):
+
+    def setUp(self):
+        super(APIKeyModelTest, self).setUp()
+        self.user = User.objects.create_user("Test user", "test@example.com", "password")
+
+    def tearDown(self):
+        super(APIKeyModelTest, self).tearDown()
+        # Some tests already delete the user
+        if self.user.id:
+            self.user.delete()
+
+    @override_settings(REDIS_API_NAME='test_api')
+    def test_redis_api_key(self):
+        key = APIKey.objects.create(user=self.user, key="test_key")
+        self.assertEqual("key:test_key:api:test_api", key.redis_key)
+        key.delete()
+
+    @override_settings(REDIS_API_NAME='test_api')
+    def test_sets_key_in_redis(self):
+        expected_key = "key:test_key:api:test_api"
+        r = redis_connection()
+        self.assertIsNone(r.get(expected_key))
+        key = APIKey.objects.create(user=self.user, key="test_key")
+        self.assertEqual(r.get(expected_key), '1')
+        key.delete()
+
+    @override_settings(REDIS_API_NAME='test_api')
+    def test_deletes_key_from_redis(self):
+        expected_key = "key:test_key:api:test_api"
+        r = redis_connection()
+        key = APIKey.objects.create(user=self.user, key="test_key")
+        self.assertEqual(r.get(expected_key), '1')
+        key.delete()
+        self.assertIsNone(r.get(expected_key))
+
+    @override_settings(REDIS_API_NAME='test_api')
+    def test_deleted_users_cascade(self):
+        expected_key = "key:test_key:api:test_api"
+        key = APIKey.objects.create(user=self.user, key="test_key")
+        r = redis_connection()
+        self.assertEqual(r.get(expected_key), '1')
+        self.user.delete()
+        with self.assertRaises(APIKey.DoesNotExist):
+            APIKey.objects.get(pk=key.pk)
+        self.assertIsNone(r.get(expected_key))

--- a/api_keys/utils.py
+++ b/api_keys/utils.py
@@ -1,0 +1,18 @@
+import redis
+
+from django.conf import settings
+
+
+_connection = None
+
+def redis_connection():
+    global _connection
+    if _connection is None:
+        _connection = redis.StrictRedis(
+            host=settings.REDIS_DB_HOST,
+            port=settings.REDIS_DB_PORT,
+            db=settings.REDIS_DB_NUMBER,
+            password=settings.REDIS_DB_PASSWORD
+        )
+    return _connection
+

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -11,6 +11,11 @@ MAPIT_DB_PASS: ''
 MAPIT_DB_HOST: null
 MAPIT_DB_PORT: null
 
+REDIS_DB_HOST: 'localhost'
+REDIS_DB_PORT: 6379
+REDIS_DB_NUMBER: 0
+REDIS_DB_PASSWORD: null
+
 # Country is currently one of GB, NO, or KE. Optional; country specific things won't happen if not set.
 COUNTRY: 'GB'
 
@@ -45,3 +50,4 @@ SITE_NAME: 'MapIt: UK'
 # An email address for support enquiries (Used by django-user-acounts to give
 # people signing up someone to contact for example)
 CONTACT_EMAIL: support@example.org
+EMAIL_PORT: 25

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -51,3 +51,6 @@ SITE_NAME: 'MapIt: UK'
 # people signing up someone to contact for example)
 CONTACT_EMAIL: support@example.org
 EMAIL_PORT: 25
+
+# The name of this api in the redis api management db
+REDIS_API_NAME: 'mapit.mysociety.org'

--- a/mapit-gb/settings.py
+++ b/mapit-gb/settings.py
@@ -250,3 +250,6 @@ REDIS_DB_HOST = config.get('REDIS_DB_HOST')
 REDIS_DB_PORT = config.get('REDIS_DB_PORT')
 REDIS_DB_NUMBER = config.get('REDIS_DB_NUMBER')
 REDIS_DB_PASSWORD = config.get('REDIS_DB_PASSWORD')
+
+# Configurable email port, to make it easier to develop email sending
+EMAIL_PORT = config.get('EMAIL_PORT', 25)

--- a/mapit-gb/settings.py
+++ b/mapit-gb/settings.py
@@ -145,11 +145,13 @@ STATICFILES_FINDERS = (
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
-    ('django.template.loaders.cached.Loader', (
-        'django.template.loaders.filesystem.Loader',
-        'django.template.loaders.app_directories.Loader',
-    )),
+    'django.template.loaders.filesystem.Loader',
+    'django.template.loaders.app_directories.Loader',
 )
+if not DEBUG:
+    TEMPLATE_LOADERS = (
+        ('django.template.loaders.cached.Loader', TEMPLATE_LOADERS),
+    )
 
 # UpdateCacheMiddleware does ETag setting, and
 # ConditionalGetMiddleware does ETag checking.

--- a/mapit-gb/settings.py
+++ b/mapit-gb/settings.py
@@ -244,3 +244,9 @@ SITE_NAME = config.get('SITE_NAME', 'MapIt')
 # django-user-accounts settings
 ACCOUNT_EMAIL_CONFIRMATION_REQUIRED = True
 THEME_CONTACT_EMAIL = config.get('CONTACT_EMAIL', '')
+
+# Redis connection for syncing user accounts with Varnish
+REDIS_DB_HOST = config.get('REDIS_DB_HOST')
+REDIS_DB_PORT = config.get('REDIS_DB_PORT')
+REDIS_DB_NUMBER = config.get('REDIS_DB_NUMBER')
+REDIS_DB_PASSWORD = config.get('REDIS_DB_PASSWORD')

--- a/mapit-gb/settings.py
+++ b/mapit-gb/settings.py
@@ -253,3 +253,7 @@ REDIS_DB_PASSWORD = config.get('REDIS_DB_PASSWORD')
 
 # Configurable email port, to make it easier to develop email sending
 EMAIL_PORT = config.get('EMAIL_PORT', 25)
+
+# TEST_RUNNER is a required setting from Django 1.6 onwards
+if django.get_version() >= '1.6':
+    TEST_RUNNER = 'django.test.runner.DiscoverRunner'

--- a/mapit-gb/settings.py
+++ b/mapit-gb/settings.py
@@ -257,3 +257,8 @@ EMAIL_PORT = config.get('EMAIL_PORT', 25)
 # TEST_RUNNER is a required setting from Django 1.6 onwards
 if django.get_version() >= '1.6':
     TEST_RUNNER = 'django.test.runner.DiscoverRunner'
+
+# The name of this api in the redis api management db
+REDIS_API_NAME = config.get('REDIS_API_NAME')
+
+ACCOUNT_DELETION_EXPUNGE_HOURS = 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 django-mapit==1.3.1.post1
 django-user-accounts==1.0.1
+mock==1.0.1
+mockredispy==2.9.0.10
 redis==2.10.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 django-mapit==1.3.1.post1
 django-user-accounts==1.0.1
+redis==2.10.3


### PR DESCRIPTION
Basic functionality to sync api keys in the Django database with a redis
database that Varnish can look at to manage requests.
- SETs an appropriate key whenever the APIKey is saved
- UNSETs the key when the APIKey is deleted
