### PR TITLE
Add management commands to control restricting and throttling the api

### DIFF
--- a/api_keys/admin.py
+++ b/api_keys/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/api_keys/management/commands/api_keys_restrict_api.py
+++ b/api_keys/management/commands/api_keys_restrict_api.py
@@ -1,0 +1,22 @@
+# This script is used to manage restricting access to this site's API through
+# a Varnish-based api management system.
+
+from django.core.management.base import NoArgsCommand
+from django.conf import settings
+
+from ...utils import redis_connection, RedisStrings
+
+class Command(NoArgsCommand):
+    help = """Restrict access the api named in settings.REDIS_API_NAME if
+             settings.API_RESTRICT is True, un-restrict it otherwise."""
+
+    def handle_noargs(self, **options):
+        r = redis_connection()
+        if settings.API_RESTRICT:
+            r.set(RedisStrings.API_RESTRICT, '1')
+            if options['verbosity'] > 2:
+                self.stdout.write("Restricted api: {0}".format(settings.REDIS_API_NAME))
+        else:
+            r.delete(RedisStrings.API_RESTRICT)
+            if options['verbosity'] > 2:
+                self.stdout.write("Removed restriction on api: {0}".format(settings.REDIS_API_NAME))

--- a/api_keys/management/commands/api_keys_throttle_api.py
+++ b/api_keys/management/commands/api_keys_throttle_api.py
@@ -1,0 +1,30 @@
+# This script is used to manage throttling access to this site's API through
+# a Varnish-based api management system.
+
+from django.core.management.base import NoArgsCommand
+from django.conf import settings
+
+from ...utils import redis_connection, RedisStrings
+
+class Command(NoArgsCommand):
+    help = """Throttle access to the api named in settings.REDIS_API_NAME if
+            settings.API_THROTTLE is True, un-throttle it otherwise."""
+
+    def handle_noargs(self, **options):
+        r = redis_connection()
+        r = redis_connection()
+        if settings.API_THROTTLE:
+            r.set(RedisStrings.API_THROTTLE, '1')
+            r.set(RedisStrings.API_THROTTLE_COUNTER, settings.API_THROTTLE_COUNTER)
+            r.set(RedisStrings.API_THROTTLE_BLOCKED, settings.API_THROTTLE_BLOCKED)
+            r.set(RedisStrings.API_THROTTLE_DEFAULT_LIMIT, settings.API_THROTTLE_DEFAULT_LIMIT)
+            if options['verbosity'] > 2:
+                self.stdout.write("Throttled api: {0}".format(settings.REDIS_API_NAME))
+                self.stdout.write("Set throttling to {0} hits in {1} seconds, blocking offenders for {2} seconds.".format(settings.API_THROTTLE_DEFAULT_LIMIT, settings.API_THROTTLE_COUNTER, settings.API_THROTTLE_BLOCKED))
+        else:
+            r.delete(RedisStrings.API_THROTTLE)
+            r.delete(RedisStrings.API_THROTTLE_COUNTER)
+            r.delete(RedisStrings.API_THROTTLE_BLOCKED)
+            r.delete(RedisStrings.API_THROTTLE_DEFAULT_LIMIT)
+            if options['verbosity'] > 2:
+                self.stdout.write("Removed throttling on api: {0}".format(settings.REDIS_API_NAME))

--- a/api_keys/migrations/0001_initial.py
+++ b/api_keys/migrations/0001_initial.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='APIKey',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('key', models.CharField(unique=True, max_length=40, blank=True)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/api_keys/migrations/0002_auto_20150323_1737.py
+++ b/api_keys/migrations/0002_auto_20150323_1737.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api_keys', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='apikey',
+            name='key',
+            field=models.CharField(unique=True, max_length=40),
+            preserve_default=True,
+        ),
+    ]

--- a/api_keys/migrations/0003_auto_20150323_1802.py
+++ b/api_keys/migrations/0003_auto_20150323_1802.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api_keys', '0002_auto_20150323_1737'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='apikey',
+            name='user',
+            field=models.ForeignKey(related_name='api_key', to=settings.AUTH_USER_MODEL),
+            preserve_default=True,
+        ),
+    ]

--- a/api_keys/migrations/0004_auto_20150323_1824.py
+++ b/api_keys/migrations/0004_auto_20150323_1824.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api_keys', '0003_auto_20150323_1802'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='apikey',
+            name='user',
+            field=models.OneToOneField(related_name='api_key', to=settings.AUTH_USER_MODEL),
+            preserve_default=True,
+        ),
+    ]

--- a/api_keys/models.py
+++ b/api_keys/models.py
@@ -1,0 +1,38 @@
+import string
+import random
+
+from django.db import models
+from django.dispatch import receiver
+from django.conf import settings
+
+from account.signals import user_signed_up
+
+
+# Inspired by https://github.com/CIGIHub/django-simple-api-key
+class APIKey(models.Model):
+    user = models.OneToOneField(settings.AUTH_USER_MODEL, related_name='api_key')
+    key = models.CharField(max_length=40, blank=False, unique=True)
+
+    def __unicode__(self):
+        return "%s: %s" % (self.user, self.key)
+
+    @staticmethod
+    def generate_key(size=40, chars=string.ascii_letters + string.digits):
+        return ''.join(random.choice(chars) for x in range(size))
+
+
+@receiver(user_signed_up)
+def create_key_for_new_user(user, form, **kwargs):
+    """Create a new APIKey for a user who just signed up."""
+
+    # If there was a key already for them (who know's, it could happen) we
+    # delete it, assuming that the user account system has responsibility for
+    # making sure the account should exist.
+    try:
+        key = APIKey.objects.get(user=user)
+        key.delete()
+    except APIKey.DoesNotExist:
+        pass
+
+    APIKey.objects.create(user=user, key=APIKey.generate_key())
+

--- a/api_keys/templates/api_keys/api_key_detail.html
+++ b/api_keys/templates/api_keys/api_key_detail.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "API Key" %}{% endblock %}
+
+{% block content %}
+    <h1>{% trans "API Key" %}</h1>
+    <p>Your API Key is:</p>
+    <pre>{{ api_key.key }}</pre>
+{% endblock %}

--- a/api_keys/tests.py
+++ b/api_keys/tests.py
@@ -1,0 +1,53 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
+
+from account.signals import user_signed_up
+
+from .models import APIKey, create_key_for_new_user
+
+
+class SignalsTest(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_user("Test user", "test@example.com", "password")
+
+    def tearDown(self):
+        self.user.delete()
+
+    def test_creates_key_when_user_signs_up(self):
+        self.assertFalse(APIKey.objects.filter(user=self.user).exists())
+        user_signed_up.send(self.__class__, user=self.user, form={})
+        self.assertTrue(APIKey.objects.filter(user=self.user).exists())
+
+    def test_deletes_existing_key(self):
+        key = APIKey.objects.create(user=self.user, key=APIKey.generate_key())
+        create_key_for_new_user(self.user, form={})
+        self.assertNotEqual(key, APIKey.objects.get(user=self.user))
+
+
+class APIKeyDetailViewTest(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_user("Test user", "test@example.com", "password")
+        self.key = APIKey.objects.create(user=self.user, key=APIKey.generate_key())
+
+    def tearDown(self):
+        self.user.delete()
+        self.key.delete()
+
+    def test_view_requires_login(self):
+        url = reverse('api_keys_key')
+        self.client.logout()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+        self.client.login(username="Test user", password="password")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
+    def test_prints_api_key(self):
+        url = reverse('api_keys_key')
+        self.client.login(username="Test user", password="password")
+        response = self.client.get(url)
+        self.assertContains(response, self.key.key)

--- a/api_keys/tests.py
+++ b/api_keys/tests.py
@@ -1,38 +1,62 @@
+from mock import patch
+from mockredis import mock_strict_redis_client
+
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 
 from account.signals import user_signed_up
 
 from .models import APIKey, create_key_for_new_user
+from .utils import redis_connection
 
 
-class SignalsTest(TestCase):
+class PatchedRedisTestCase(TestCase):
+    """
+    Helper TestCase subclass that patches the redis library.
+    """
 
     def setUp(self):
+        self.redis_patcher = patch('api_keys.utils.redis.StrictRedis', mock_strict_redis_client)
+        self.redis_patcher.start()
+
+    def tearDown(self):
+        self.redis_patcher.stop()
+
+
+class SignalsTest(PatchedRedisTestCase):
+
+    def setUp(self):
+        super(SignalsTest, self).setUp()
         self.user = User.objects.create_user("Test user", "test@example.com", "password")
 
     def tearDown(self):
+        super(SignalsTest, self).tearDown()
         self.user.delete()
 
     def test_creates_key_when_user_signs_up(self):
         self.assertFalse(APIKey.objects.filter(user=self.user).exists())
         user_signed_up.send(self.__class__, user=self.user, form={})
         self.assertTrue(APIKey.objects.filter(user=self.user).exists())
+        APIKey.objects.get(user=self.user).delete()
 
     def test_deletes_existing_key(self):
         key = APIKey.objects.create(user=self.user, key=APIKey.generate_key())
         create_key_for_new_user(self.user, form={})
         self.assertNotEqual(key, APIKey.objects.get(user=self.user))
+        key.delete()
 
 
-class APIKeyDetailViewTest(TestCase):
+class APIKeyDetailViewTest(PatchedRedisTestCase):
 
     def setUp(self):
+        super(APIKeyDetailViewTest, self).setUp()
         self.user = User.objects.create_user("Test user", "test@example.com", "password")
         self.key = APIKey.objects.create(user=self.user, key=APIKey.generate_key())
 
     def tearDown(self):
+        super(APIKeyDetailViewTest, self).tearDown()
         self.user.delete()
         self.key.delete()
 
@@ -51,3 +75,51 @@ class APIKeyDetailViewTest(TestCase):
         self.client.login(username="Test user", password="password")
         response = self.client.get(url)
         self.assertContains(response, self.key.key)
+
+
+class APIKeyModelTest(PatchedRedisTestCase):
+
+    def setUp(self):
+        super(APIKeyModelTest, self).setUp()
+        self.user = User.objects.create_user("Test user", "test@example.com", "password")
+
+    def tearDown(self):
+        super(APIKeyModelTest, self).tearDown()
+        # Some tests already delete the user
+        if self.user.id:
+            self.user.delete()
+
+    @override_settings(REDIS_API_NAME='test_api')
+    def test_redis_api_key(self):
+        key = APIKey.objects.create(user=self.user, key="test_key")
+        self.assertEqual("key:test_key:api:test_api", key.redis_key)
+        key.delete()
+
+    @override_settings(REDIS_API_NAME='test_api')
+    def test_sets_key_in_redis(self):
+        expected_key = "key:test_key:api:test_api"
+        r = redis_connection()
+        self.assertIsNone(r.get(expected_key))
+        key = APIKey.objects.create(user=self.user, key="test_key")
+        self.assertEqual(r.get(expected_key), '1')
+        key.delete()
+
+    @override_settings(REDIS_API_NAME='test_api')
+    def test_deletes_key_from_redis(self):
+        expected_key = "key:test_key:api:test_api"
+        r = redis_connection()
+        key = APIKey.objects.create(user=self.user, key="test_key")
+        self.assertEqual(r.get(expected_key), '1')
+        key.delete()
+        self.assertIsNone(r.get(expected_key), '1')
+
+    @override_settings(REDIS_API_NAME='test_api')
+    def test_deleted_users_cascade(self):
+        expected_key = "key:test_key:api:test_api"
+        key = APIKey.objects.create(user=self.user, key="test_key")
+        r = redis_connection()
+        self.assertEqual(r.get(expected_key), '1')
+        self.user.delete()
+        with self.assertRaises(APIKey.DoesNotExist):
+            APIKey.objects.get(pk=key.pk)
+        self.assertIsNone(r.get(expected_key), '1')

--- a/api_keys/tests.py
+++ b/api_keys/tests.py
@@ -162,6 +162,7 @@ class ThrottleAPICommandTest(PatchedRedisTestCase):
         self.assertIsNone(r.get(RedisStrings.API_THROTTLE_COUNTER))
         self.assertIsNone(r.get(RedisStrings.API_THROTTLE_BLOCKED))
         self.assertIsNone(r.get(RedisStrings.API_THROTTLE_DEFAULT_LIMIT))
+        self.assertIsNone(r.get(RedisStrings.rate_limit_string('127.0.0.1')))
 
         call_command('api_keys_throttle_api', stdout=StringIO(), stderr=StringIO())
 
@@ -169,6 +170,7 @@ class ThrottleAPICommandTest(PatchedRedisTestCase):
         self.assertEqual(r.get(RedisStrings.API_THROTTLE_COUNTER), '360')
         self.assertEqual(r.get(RedisStrings.API_THROTTLE_BLOCKED), '360')
         self.assertEqual(r.get(RedisStrings.API_THROTTLE_DEFAULT_LIMIT), '360')
+        self.assertEqual(r.get(RedisStrings.rate_limit_string('127.0.0.1')), '0')
 
     @override_settings(REDIS_API_NAME='test_api', API_THROTTLE=False)
     def test_unthrottles_api(self):

--- a/api_keys/urls.py
+++ b/api_keys/urls.py
@@ -1,0 +1,8 @@
+from django.conf.urls import url
+from django.contrib.auth.decorators import login_required
+
+from .views import APIKeyDetailView
+
+urlpatterns = [
+    url(r'^key', login_required(APIKeyDetailView.as_view()), name="api_keys_key"),
+]

--- a/api_keys/utils.py
+++ b/api_keys/utils.py
@@ -1,0 +1,18 @@
+import redis
+
+from django.conf import settings
+
+
+_connection = None
+
+def redis_connection():
+    global _connection
+    if _connection is None:
+        _connection = redis.StrictRedis(
+            host=settings.REDIS_DB_HOST,
+            port=settings.REDIS_DB_PORT,
+            db=settings.REDIS_DB_NUMBER,
+            password=settings.REDIS_DB_PASSWORD
+        )
+    return _connection
+

--- a/api_keys/utils.py
+++ b/api_keys/utils.py
@@ -16,3 +16,10 @@ def redis_connection():
         )
     return _connection
 
+class RedisStrings(object):
+    API_RESTRICT = 'api:{0}:restricted'.format(settings.REDIS_API_NAME)
+    API_THROTTLE = 'api:{0}:restricted'.format(settings.REDIS_API_NAME)
+    API_THROTTLE_COUNTER = 'api:{0}:counter'.format(settings.REDIS_API_NAME)
+    API_THROTTLE_BLOCKED = 'api:{0}:blocked'.format(settings.REDIS_API_NAME)
+    API_THROTTLE_DEFAULT_LIMIT = 'api:{0}:default_max'.format(settings.REDIS_API_NAME)
+

--- a/api_keys/utils.py
+++ b/api_keys/utils.py
@@ -23,3 +23,7 @@ class RedisStrings(object):
     API_THROTTLE_BLOCKED = 'api:{0}:blocked'.format(settings.REDIS_API_NAME)
     API_THROTTLE_DEFAULT_LIMIT = 'api:{0}:default_max'.format(settings.REDIS_API_NAME)
 
+    @staticmethod
+    def rate_limit_string(identity):
+        return "key:{0}:usage:{1}:max".format(identity, settings.REDIS_API_NAME)
+

--- a/api_keys/views.py
+++ b/api_keys/views.py
@@ -1,0 +1,9 @@
+from django.views.generic import DetailView
+
+
+class APIKeyDetailView(DetailView):
+    template_name = 'api_keys/api_key_detail.html'
+    context_object_name = 'api_key'
+
+    def get_object(self, queryset=None):
+        return self.request.user.api_key

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -48,9 +48,30 @@ SITE_BASE_URL: 'http://www.example.com'
 SITE_NAME: 'MapIt: UK'
 
 # An email address for support enquiries (Used by django-user-acounts to give
-people signing up someone to contact for example)
+# people signing up someone to contact for example)
 CONTACT_EMAIL: support@example.org
 EMAIL_PORT: 25
 
 # The name of this api in the redis api management db
 REDIS_API_NAME: 'mapit.mysociety.org'
+
+# Should the API be restricted to users with API Keys only?
+# Note: you can still have api keys and set rate limits on them independently
+# of this setting
+API_RESTRICT: False
+
+# Should the API be throttled?
+API_THROTTLE: False
+
+# How long a time period should the api rate limiter counts hits over (seconds)
+API_RATE_LIMIT_COUNTER_TIME: 360
+
+# How many hits during the API_RATE_LIMIT_COUNTER_TIME can a single user make
+# by default?
+# Note: you can still set limits, or have no limit at all, for individual api
+# keys or IP addresses indepent of this setting
+API_RATE_LIMIT_DEFAULT: 360
+
+# How long should users who go over the rate limit be blocked for? (Seconds)
+API_RATE_LIMIT_BLOCK_TIME: 360
+

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -11,6 +11,11 @@ MAPIT_DB_PASS: ''
 MAPIT_DB_HOST: null
 MAPIT_DB_PORT: null
 
+REDIS_DB_HOST: 'localhost'
+REDIS_DB_PORT: 6379
+REDIS_DB_NUMBER: 0
+REDIS_DB_PASSWORD: null
+
 # Country is currently one of GB, NO, or KE. Optional; country specific things won't happen if not set.
 COUNTRY: 'GB'
 
@@ -45,3 +50,4 @@ SITE_NAME: 'MapIt: UK'
 # An email address for support enquiries (Used by django-user-acounts to give
 people signing up someone to contact for example)
 CONTACT_EMAIL: support@example.org
+EMAIL_PORT: 25

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -75,3 +75,6 @@ API_THROTTLE_DEFAULT: 360
 # How long should users who go over the rate limit be blocked for? (Seconds)
 API_THROTTLE_BLOCK_TIME: 360
 
+# A list of api keys or IP addresses to exclude from rate limiting
+API_THROTTLE_UNLIMITED:
+    - '127.0.0.1'

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -64,14 +64,14 @@ API_RESTRICT: False
 API_THROTTLE: False
 
 # How long a time period should the api rate limiter counts hits over (seconds)
-API_RATE_LIMIT_COUNTER_TIME: 360
+API_THROTTLE_COUNTER_TIME: 360
 
 # How many hits during the API_RATE_LIMIT_COUNTER_TIME can a single user make
 # by default?
 # Note: you can still set limits, or have no limit at all, for individual api
 # keys or IP addresses indepent of this setting
-API_RATE_LIMIT_DEFAULT: 360
+API_THROTTLE_DEFAULT: 360
 
 # How long should users who go over the rate limit be blocked for? (Seconds)
-API_RATE_LIMIT_BLOCK_TIME: 360
+API_THROTTLE_BLOCK_TIME: 360
 

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -51,3 +51,6 @@ SITE_NAME: 'MapIt: UK'
 people signing up someone to contact for example)
 CONTACT_EMAIL: support@example.org
 EMAIL_PORT: 25
+
+# The name of this api in the redis api management db
+REDIS_API_NAME: 'mapit.mysociety.org'

--- a/mapit-gb/settings.py
+++ b/mapit-gb/settings.py
@@ -132,6 +132,7 @@ STATICFILES_DIRS = (
     # Put strings here, like "/home/html/static" or "C:/www/django/static".
     # Always use forward slashes, even on Windows.
     # Don't forget to use absolute paths, not relative paths.
+    os.path.join(BASE_DIR, 'static'),
 )
 
 # List of finder classes that know how to find static files in
@@ -240,5 +241,3 @@ SITE_NAME = config.get('SITE_NAME', 'MapIt')
 # django-user-accounts settings
 ACCOUNT_EMAIL_CONFIRMATION_REQUIRED = True
 THEME_CONTACT_EMAIL = config.get('CONTACT_EMAIL', '')
-
-EMAIL_PORT = 1025

--- a/mapit-gb/settings.py
+++ b/mapit-gb/settings.py
@@ -265,4 +265,22 @@ if django.get_version() >= '1.6':
 # The name of this api in the redis api management db
 REDIS_API_NAME = config.get('REDIS_API_NAME')
 
-ACCOUNT_DELETION_EXPUNGE_HOURS = 0
+# Should the API be restricted to users with API Keys only?
+# Note: you can still have api keys and set rate limits on them independently
+# of this setting
+API_RESTRICT = config.get('API_RESTRICT')
+
+# Should the API be throttled?
+API_THROTTLE = config.get('API_THROTTLE')
+
+# How long a time period should the api rate limiter counts hits over (seconds)
+API_RATE_LIMIT_COUNTER_TIME = config.get('API_RATE_LIMIT_COUNTER_TIME')
+
+# How many hits during the API_RATE_LIMIT_COUNTER_TIME can a single user make
+# by default?
+# Note: you can still set limits, or have no limit at all, for individual api
+# keys or IP addresses indepent of this setting
+API_RATE_LIMIT_DEFAULT = config.get('API_RATE_LIMIT_DEFAULT')
+
+# How long should users who go over the rate limit be blocked for? (Seconds)
+API_RATE_LIMIT_BLOCK_TIME = config.get('API_RATE_LIMIT_BLOCK_TIME')

--- a/mapit-gb/settings.py
+++ b/mapit-gb/settings.py
@@ -144,12 +144,18 @@ STATICFILES_FINDERS = (
 )
 
 # List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    ('django.template.loaders.cached.Loader', (
+if DEBUG:
+    TEMPLATE_LOADERS = (
         'django.template.loaders.filesystem.Loader',
         'django.template.loaders.app_directories.Loader',
-    )),
-)
+    )
+else:
+    TEMPLATE_LOADERS = (
+        ('django.template.loaders.cached.Loader', (
+            'django.template.loaders.filesystem.Loader',
+            'django.template.loaders.app_directories.Loader',
+        )),
+    )
 
 # UpdateCacheMiddleware does ETag setting, and
 # ConditionalGetMiddleware does ETag checking.

--- a/mapit-gb/settings.py
+++ b/mapit-gb/settings.py
@@ -284,3 +284,7 @@ API_THROTTLE_DEFAULT = config.get('API_THROTTLE_DEFAULT')
 
 # How long should users who go over the rate limit be blocked for? (Seconds)
 API_THROTTLE_BLOCK_TIME = config.get('API_THROTTLE_BLOCK_TIME')
+
+# A list of api keys or IP addresses to exclude from rate limiting
+# Take this from Mapit's existing setting for now
+API_THROTTLE_UNLIMITED = MAPIT_RATE_LIMIT

--- a/mapit-gb/settings.py
+++ b/mapit-gb/settings.py
@@ -248,3 +248,9 @@ SITE_NAME = config.get('SITE_NAME', 'MapIt')
 # django-user-accounts settings
 ACCOUNT_EMAIL_CONFIRMATION_REQUIRED = True
 THEME_CONTACT_EMAIL = config.get('CONTACT_EMAIL', '')
+
+# Redis connection for syncing user accounts with Varnish
+REDIS_DB_HOST = config.get('REDIS_DB_HOST')
+REDIS_DB_PORT = config.get('REDIS_DB_PORT')
+REDIS_DB_NUMBER = config.get('REDIS_DB_NUMBER')
+REDIS_DB_PASSWORD = config.get('REDIS_DB_PASSWORD')

--- a/mapit-gb/settings.py
+++ b/mapit-gb/settings.py
@@ -217,6 +217,7 @@ INSTALLED_APPS = [
     'mapit-gb',
     'mapit',
     'account',
+    'api_keys',
 ]
 if django.get_version() < '1.7':
     INSTALLED_APPS.append('south')

--- a/mapit-gb/settings.py
+++ b/mapit-gb/settings.py
@@ -261,3 +261,8 @@ EMAIL_PORT = config.get('EMAIL_PORT', 25)
 # TEST_RUNNER is a required setting from Django 1.6 onwards
 if django.get_version() >= '1.6':
     TEST_RUNNER = 'django.test.runner.DiscoverRunner'
+
+# The name of this api in the redis api management db
+REDIS_API_NAME = config.get('REDIS_API_NAME')
+
+ACCOUNT_DELETION_EXPUNGE_HOURS = 0

--- a/mapit-gb/settings.py
+++ b/mapit-gb/settings.py
@@ -274,13 +274,13 @@ API_RESTRICT = config.get('API_RESTRICT')
 API_THROTTLE = config.get('API_THROTTLE')
 
 # How long a time period should the api rate limiter counts hits over (seconds)
-API_RATE_LIMIT_COUNTER_TIME = config.get('API_RATE_LIMIT_COUNTER_TIME')
+API_THROTTLE_COUNTER_TIME = config.get('API_THROTTLE_COUNTER_TIME')
 
 # How many hits during the API_RATE_LIMIT_COUNTER_TIME can a single user make
 # by default?
 # Note: you can still set limits, or have no limit at all, for individual api
 # keys or IP addresses indepent of this setting
-API_RATE_LIMIT_DEFAULT = config.get('API_RATE_LIMIT_DEFAULT')
+API_THROTTLE_DEFAULT = config.get('API_THROTTLE_DEFAULT')
 
 # How long should users who go over the rate limit be blocked for? (Seconds)
-API_RATE_LIMIT_BLOCK_TIME = config.get('API_RATE_LIMIT_BLOCK_TIME')
+API_THROTTLE_BLOCK_TIME = config.get('API_THROTTLE_BLOCK_TIME')

--- a/mapit-gb/settings.py
+++ b/mapit-gb/settings.py
@@ -254,3 +254,6 @@ REDIS_DB_HOST = config.get('REDIS_DB_HOST')
 REDIS_DB_PORT = config.get('REDIS_DB_PORT')
 REDIS_DB_NUMBER = config.get('REDIS_DB_NUMBER')
 REDIS_DB_PASSWORD = config.get('REDIS_DB_PASSWORD')
+
+# Configurable email port, to make it easier to develop email sending
+EMAIL_PORT = config.get('EMAIL_PORT', 25)

--- a/mapit-gb/settings.py
+++ b/mapit-gb/settings.py
@@ -257,3 +257,7 @@ REDIS_DB_PASSWORD = config.get('REDIS_DB_PASSWORD')
 
 # Configurable email port, to make it easier to develop email sending
 EMAIL_PORT = config.get('EMAIL_PORT', 25)
+
+# TEST_RUNNER is a required setting from Django 1.6 onwards
+if django.get_version() >= '1.6':
+    TEST_RUNNER = 'django.test.runner.DiscoverRunner'

--- a/mapit-gb/templates/account/_form_fields.html
+++ b/mapit-gb/templates/account/_form_fields.html
@@ -1,10 +1,16 @@
+{% if form.non_field_errors %}
+<div class="account-form__errors">
+    {{ form.non_field_errors }}
+</div>
+</div>
+{% endif %}
 {% for field in form %}
     {% if field.is_hidden %}
         {{ field }}
     {% else %}
         <div class="account-form__field">
             <div class="account-form__label">{{ field.label_tag }}</div>
-            <div class="account-form__input">{{ field }}</div>
+            <div class="account-form__input{% if field.errors %} account-form__input--error{% endif %}">{{ field }}</div>
             {% if field.errors %}
                 <div class="account-form__errors">{{ field.errors }}</div>
             {% endif %}

--- a/mapit-gb/templates/account/_form_fields.html
+++ b/mapit-gb/templates/account/_form_fields.html
@@ -1,0 +1,16 @@
+{% for field in form %}
+    {% if field.is_hidden %}
+        {{ field }}
+    {% else %}
+        <div class="account-form__field">
+            <div class="account-form__label">{{ field.label_tag }}</div>
+            <div class="account-form__input">{{ field }}</div>
+            {% if field.errors %}
+                <div class="account-form__errors">{{ field.errors }}</div>
+            {% endif %}
+        </div>
+    {% endif %}
+{% endfor %}
+{% if redirect_field_value %}
+    <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+{% endif %}

--- a/mapit-gb/templates/account/_logged_in_nav.html
+++ b/mapit-gb/templates/account/_logged_in_nav.html
@@ -4,5 +4,6 @@
     <li><a href="{% url 'account_logout' %}">{% trans "Log out" %}</a></li>
     <li><a href="{% url 'account_password' %}">{% trans "Change password" %}</a></li>
     <li><a href="{% url 'account_settings' %}">{% trans "Account settings" %}</a></li>
+    <li><a href="{% url 'api_keys_key' %}">{% trans "API Key" %}</a></li>
     <li><a href="{% url 'account_delete' %}">{% trans "Delete account" %}</a></li>
 </ul>

--- a/mapit-gb/templates/account/_logged_in_nav.html
+++ b/mapit-gb/templates/account/_logged_in_nav.html
@@ -1,0 +1,8 @@
+{% load i18n %}
+<p>Account</p>
+<ul>
+    <li><a href="{% url 'account_logout' %}">{% trans "Log out" %}</a></li>
+    <li><a href="{% url 'account_password' %}">{% trans "Change password" %}</a></li>
+    <li><a href="{% url 'account_settings' %}">{% trans "Account settings" %}</a></li>
+    <li><a href="{% url 'account_delete' %}">{% trans "Delete account" %}</a></li>
+</ul>

--- a/mapit-gb/templates/account/_logged_in_sidebar.html
+++ b/mapit-gb/templates/account/_logged_in_sidebar.html
@@ -1,15 +1,8 @@
 {% load url from compat %}
-{% load i18n %}
 
 <header class="account-header">
     <h2>MapIt API</h2>
     <nav class="toc">
-        <p>Account</p>
-        <ul>
-            <li><a href="{% url 'account_logout' %}">{% trans "Log out" %}</a></li>
-            <li><a href="{% url 'account_password' %}">{% trans "Change password" %}</a></li>
-            <li><a href="{% url 'account_settings' %}">{% trans "Account settings" %}</a></li>
-            <li><a href="{% url 'account_delete' %}">{% trans "Delete account" %}</a></li>
-        </ul>
+        {% include 'account/_logged_in_nav.html' %}
     </nav>
 </header>

--- a/mapit-gb/templates/account/_logged_in_sidebar.html
+++ b/mapit-gb/templates/account/_logged_in_sidebar.html
@@ -1,7 +1,7 @@
 {% load url from compat %}
 {% load i18n %}
 
-<header>
+<header class="account-header">
     <h2>MapIt API</h2>
     <nav class="toc">
         <p>Account</p>

--- a/mapit-gb/templates/account/_signup_nav.html
+++ b/mapit-gb/templates/account/_signup_nav.html
@@ -1,0 +1,8 @@
+{% load i18n %}
+<p>Account</p>
+<ul>
+    <li><a href="{% url 'account_login' %}">{% trans "Log in" %}</a></li>
+    {% if ACCOUNT_OPEN_SIGNUP %}
+        <li><a href="{% url 'account_signup' %}">{% trans "Sign up" %}</a></li>
+    {% endif %}
+</ul>

--- a/mapit-gb/templates/account/_signup_sidebar.html
+++ b/mapit-gb/templates/account/_signup_sidebar.html
@@ -1,15 +1,8 @@
 {% load url from compat %}
-{% load i18n %}
 
 <header class="account-header">
     <h2>MapIt API</h2>
     <nav class="toc">
-        <p>Account</p>
-        <ul>
-            <li><a href="{% url 'account_login' %}">{% trans "Log in" %}</a></li>
-            {% if ACCOUNT_OPEN_SIGNUP %}
-                <li><a href="{% url 'account_signup' %}">{% trans "Sign up" %}</a></li>
-            {% endif %}
-        </ul>
+        {% include 'account/_signup_nav.html' %}
     </nav>
 </header>

--- a/mapit-gb/templates/account/delete.html
+++ b/mapit-gb/templates/account/delete.html
@@ -1,4 +1,4 @@
-{% extends "mapit/base.html" %}
+{% extends "account/base.html" %}
 
 {% load i18n %}
 {% load url from compat %}
@@ -6,16 +6,18 @@
 {% block title %}{% trans "Delete Account" %}{% endblock %}
 
 {% block content %}
-<article>
+<article id="api-docs">
     {% include 'account/_logged_in_sidebar.html' %}
-    <section>
-        <h1>{% trans "Delete Account" %}</h1>
+    <section class="account-form">
+        <h2>{% trans "Delete Account" %}</h2>
 
         <p>{% blocktrans %}If you go ahead and delete your account, your information will be <b>expunged within {{ ACCOUNT_DELETION_EXPUNGE_HOURS }} hours</b>.{% endblocktrans %}</p>
 
         <form method="post" action="{% url "account_delete" %}" autocapitalize="off">
             {% csrf_token %}
-            <button type="submit" class="btn">{% trans "Delete My Account" %}</button>
+            <div class="account-form__field account-form__field--submit">
+                <button type="submit" class="btn">{% trans "Delete My Account" %}</button>
+            </div>
         </form>
     </section>
 </article>

--- a/mapit-gb/templates/account/email_confirm.html
+++ b/mapit-gb/templates/account/email_confirm.html
@@ -1,4 +1,4 @@
-{% extends "mapit/base.html" %}
+{% extends "account/base.html" %}
 
 {% load url from compat %}
 {% load i18n %}
@@ -6,15 +6,16 @@
 {% block title %}{% trans "Confirm Email" %}{% endblock %}
 
 {% block content %}
-<article>
-    <section>
+<article id="api-docs">
+    {% include 'account/_signup_sidebar.html' %}
+    <section class="account-form">
+        <h2>{% trans "Confirm Email" %}</h2>
         <form method="post" action="{% url "account_confirm_email" key=confirmation.key %}">
-            <legend>{% trans "Confirm Email" %}</legend>
-            <fieldset>
-                {% csrf_token %}
-                <p>{% blocktrans with email=confirmation.email_address.email %}Confirm email address <b>{{ email }}</b>?{% endblocktrans %}</p>
-                <button type="submit" class="btn btn-primary">{% trans "Confirm" %}</button>
-            </fieldset>
+            {% csrf_token %}
+            <p>{% blocktrans with email=confirmation.email_address.email %}Confirm email address <b>{{ email }}</b>?{% endblocktrans %}</p>
+            <div class="account-form__field">
+                <button type="submit" class="btn">{% trans "Confirm" %}</button>
+            </div>
         </form>
     </section>
 </article>

--- a/mapit-gb/templates/account/email_confirmation_sent.html
+++ b/mapit-gb/templates/account/email_confirmation_sent.html
@@ -1,4 +1,4 @@
-{% extends "mapit/base.html" %}
+{% extends "account/base.html" %}
 
 {% load url from compat %}
 {% load i18n %}
@@ -6,7 +6,7 @@
 {% block title %}{% trans "Confirm your email address" %}{% endblock %}
 
 {% block content %}
-<article>
+<article id="api-docs">
     {% include 'account/_signup_sidebar.html' %}
     <section>
         <h2>{% trans "Confirm your email address" %}</h2>

--- a/mapit-gb/templates/account/email_confirmed.html
+++ b/mapit-gb/templates/account/email_confirmed.html
@@ -1,4 +1,4 @@
-{% extends "mapit/base.html" %}
+{% extends "account/base.html" %}
 
 {% load url from compat %}
 {% load i18n %}
@@ -6,10 +6,10 @@
 {% block title %}{% trans "Email confirmed" %}{% endblock %}
 
 {% block content %}
-<article>
+<article id="api-docs">
     {% include 'account/_login_sidebar.html' %}
     <section>
-        <h1>{% trans "Email confirmed" %}</h1>
+        <h2>{% trans "Email confirmed" %}</h2>
         <p>{% blocktrans with email=confirmation.email_address.email %}You have confirmed <b>{{ email }}</b>{% endblocktrans %}</p>
     </section>
 </article>

--- a/mapit-gb/templates/account/login.html
+++ b/mapit-gb/templates/account/login.html
@@ -1,4 +1,4 @@
-{% extends "mapit/base.html" %}
+{% extends "account/base.html" %}
 
 {% load url from compat %}
 {% load i18n %}
@@ -7,17 +7,16 @@
 {% block title %}{% trans "Log in" %}{% endblock %}
 
 {% block content %}
-<article>
+<article id="api-docs">
     {% include 'account/_login_sidebar.html' %}
-    <section>
+    <section class="account-form">
+        <h2>{% trans "Log in to an existing account" %}</h2>
         <form method="POST" action="{% url "account_login" %}" autocapitalize="off" {% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
-            <legend>{% trans "Log in to an existing account" %}</legend>
             {% csrf_token %}
-            {{ form }}
-            {% if redirect_field_value %}
-                <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
-            {% endif %}
-            <button type="submit" class="btn">{% trans "Log in" %}</button>
+            {% include 'account/_form_fields.html' %}
+            <div class="account-form__field account-form__field--submit">
+                <button type="submit" class="btn">{% trans "Log in" %}</button>
+            </div>
             <a href="{% url "account_password_reset" %}" class="btn">{% trans "Forgot your password?" %}</a>
         </form>
     </section>

--- a/mapit-gb/templates/account/logout.html
+++ b/mapit-gb/templates/account/logout.html
@@ -1,4 +1,4 @@
-{% extends "mapit/base.html" %}
+{% extends "account/base.html" %}
 
 {% load url from compat %}
 {% load i18n %}
@@ -6,16 +6,16 @@
 {% block title %}{% trans "Log out" %}{% endblock %}
 
 {% block content %}
-<article>
+<article id="api-docs">
     {% include 'account/_logged_in_sidebar.html' %}
-    <section>
+    <section class="account-form">
+        <h2>{% trans "Log out" %}</h2>
         <form method="POST" action="{% url "account_logout" %}">
-            <legend>{% trans "Log out" %}</legend>
-            <fieldset>
-                {% csrf_token %}
-                <p>{% trans "Are you sure you want to log out?" %}</p>
+            {% csrf_token %}
+            <p>{% trans "Are you sure you want to log out?" %}</p>
+            <div class="account-form__field account-form__field--submit">
                 <button type="submit" class="btn">{% trans "Log out" %}</button>
-            </fieldset>
+            </div>
         </form>
     </section>
 </article>

--- a/mapit-gb/templates/account/password_change.html
+++ b/mapit-gb/templates/account/password_change.html
@@ -1,4 +1,4 @@
-{% extends "mapit/base.html" %}
+{% extends "account/base.html" %}
 
 {% load url from compat %}
 {% load i18n %}
@@ -8,16 +8,16 @@
 {% block title %}{% trans "Change password" %}{% endblock %}
 
 {% block content %}
-<article>
+<article id="api-docs">
     {% include 'account/_logged_in_sidebar.html' %}
-    <section>
+    <section class="account-form">
+        <h2>{% trans "Change password" %}</h2>
         <form method="POST" action="">
-            <legend>{% trans "Change password" %}</legend>
-            <fieldset>
-                {% csrf_token %}
-                {{ form }}
+            {% csrf_token %}
+            {% include 'account/_form_fields.html' %}
+            <div class="account-form__field account-form__field--submit">
                 <button type="submit" class="btn">{% trans "Save" %}</button>
-            </fieldset>
+            </div>
         </form>
     </section>
 </article>

--- a/mapit-gb/templates/account/password_reset.html
+++ b/mapit-gb/templates/account/password_reset.html
@@ -1,4 +1,4 @@
-{% extends "mapit/base.html" %}
+{% extends "account/base.html" %}
 
 {% load url from compat %}
 {% load i18n %}
@@ -9,17 +9,19 @@
 {% user_display request.user as user_display %}
 
 {% block content %}
-<article>
+<article id="api-docs">
     {% include 'account/_login_sidebar.html' %}
-    <section>
+    <section class="account-form">
+        <h2>{% trans "Password reset" %}</h2>
         <form method="POST" action="">
-            <legend>{% trans "Password reset" %}</legend>
             <p>{% trans "Forgotten your password? Enter your email address below, and we'll send you an email allowing you to reset it." %}</p>
             {% csrf_token %}
-            {{ form }}
-            <button type="submit" class="btn">
-                {% trans "Reset my password" %}
-            </button>
+            {% include 'account/_form_fields.html' %}
+            <div class="account-form__field account-form__field--submit">
+                <button type="submit" class="btn">
+                    {% trans "Reset my password" %}
+                </button>
+            </div>
         </form>
         <p>{% blocktrans %}If you have any trouble resetting your password, contact us at <a href="mailto:{{ THEME_CONTACT_EMAIL }}">{{ THEME_CONTACT_EMAIL }}</a>.{% endblocktrans %}</p>
     </section>

--- a/mapit-gb/templates/account/password_reset_sent.html
+++ b/mapit-gb/templates/account/password_reset_sent.html
@@ -1,4 +1,4 @@
-{% extends "mapit/base.html" %}
+{% extends "account/base.html" %}
 
 {% load url from compat %}
 {% load i18n %}
@@ -7,10 +7,10 @@
 {% block title %}{% trans "Password reset sent" %}{% endblock %}
 
 {% block content %}
-<article>
+<article id="api-docs">
     {% include 'account/_login_sidebar.html' %}
-    <section>
-        <h1>{% trans "Password reset sent" %}</h1>
+    <section class="account-header">
+        <h2>{% trans "Password reset sent" %}</h2>
         {% if not resend %}
             <p>{% blocktrans %}We have sent you an email. If you do not receive it within a few minutes, try resending or contact us at <a href="mailto:{{ THEME_CONTACT_EMAIL }}">{{ THEME_CONTACT_EMAIL }}</a>.{% endblocktrans %}</p>
 
@@ -19,7 +19,9 @@
                 {% for field in form %}
                     {{ field.as_hidden }}
                 {% endfor %}
-                <button type="submit" name="resend" class="btn">{% trans "Resend" %}</button>
+                <div class="account-form__field account-form__field--submit">
+                    <button type="submit" name="resend" class="btn">{% trans "Resend" %}</button>
+                </div>
             </form>
         {% else %}
             <p>{% blocktrans %}We have resent the password email. If you do not receive it within a few minutes, contact us at <a href="mailto:{{ THEME_CONTACT_EMAIL }}">{{ THEME_CONTACT_EMAIL }}</a>.{% endblocktrans %}</p>

--- a/mapit-gb/templates/account/password_reset_token.html
+++ b/mapit-gb/templates/account/password_reset_token.html
@@ -1,4 +1,4 @@
-{% extends "mapit/base.html" %}
+{% extends "account/base.html" %}
 
 {% load url from compat %}
 {% load i18n %}
@@ -6,16 +6,16 @@
 {% block title %}{% trans "Set your new password" %}{% endblock %}
 
 {% block content %}
-<article>
+<article id="api-docs">
     {% include 'account/_login_sidebar.html' %}
-    <section>
+    <section class="account-form">
+        <h2>{% trans "Set your new password" %}</h2>
         <form method="POST" action="{% url "account_password_reset_token" uidb36=uidb36 token=token %}">
-            <legend>{% trans "Set your new password" %}</legend>
-            <fieldset>
-                {% csrf_token %}
-                {{ form }}
+            {% csrf_token %}
+            {% include 'account/_form_fields.html' %}
+            <div class="account-form__field account-form__field--submit">
                 <button type="submit" class="btn">{% trans "Save" %}</button>
-            </fieldset>
+            </div>
         </form>
     </section>
 </article>

--- a/mapit-gb/templates/account/password_reset_token_fail.html
+++ b/mapit-gb/templates/account/password_reset_token_fail.html
@@ -1,4 +1,4 @@
-{% extends "mapit/base.html" %}
+{% extends "account/base.html" %}
 
 {% load url from compat %}
 {% load i18n %}
@@ -6,10 +6,10 @@
 {% block title %}{% trans "Bad token" %}{% endblock %}
 
 {% block content %}
-<article>
+<article id="api-docs">
     {% include 'account/_login_sidebar.html' %}
     <section>
-        <h1>{% trans "Bad token" %}</h1>
+        <h2>{% trans "Bad token" %}</h2>
         {% url "account_password_reset" as url %}
         <p>{% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ url }}">new password reset</a>.{% endblocktrans %}</p>
     </section>

--- a/mapit-gb/templates/account/settings.html
+++ b/mapit-gb/templates/account/settings.html
@@ -1,4 +1,4 @@
-{% extends "mapit/base.html" %}
+{% extends "account/base.html" %}
 
 {% load url from compat %}
 {% load i18n %}
@@ -6,14 +6,16 @@
 {% block title %}{% trans "Account" %}{% endblock %}
 
 {% block content %}
-<article>
+<article id="api-docs">
     {% include 'account/_logged_in_sidebar.html' %}
-    <section>
+    <section class="account-form">
+        <h2>{% trans "Account" %}</h2>
         <form method="POST" action="{% url "account_settings" %}">
-            <legend>{% trans "Account" %}</legend>
             {% csrf_token %}
-            {{ form }}
-            <button class="btn btn-primary" type="submit">{% trans "Save" %}</button>
+            {% include 'account/_form_fields.html' %}
+            <div class="account-form__field account-form__field--submit">
+                <button class="btn btn-primary" type="submit">{% trans "Save" %}</button>
+            </div>
         </form>
     </section>
 </article>

--- a/mapit-gb/templates/account/signup.html
+++ b/mapit-gb/templates/account/signup.html
@@ -12,24 +12,9 @@
         <h2>{% trans "Sign up" %}</h2>
         <form id="signup_form" method="post" action="{% url "account_signup" %}" autocapitalize="off" {% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
             {% csrf_token %}
-            {% for field in form %}
-                {% if field.is_hidden %}
-                    {{ field }}
-                {% else %}
-                    <div class="account-form__field">
-                        <div class="account-form__label">{{ field.label_tag }}</div>
-                        <div class="account-form__input">{{ field }}</div>
-                        {% if field.errors %}
-                            <div class="account-form__errors">{{ field.errors }}</div>
-                        {% endif %}
-                    </div>
-                {% endif %}
-            {% endfor %}
-            {% if redirect_field_value %}
-                <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
-            {% endif %}
+            {% include 'account/_form_fields.html' %}
             <div class="account-form__field account-form__field--submit">
-                    <button type="submit" class="btn">{% trans "Sign up" %}</button>
+                <button type="submit" class="btn">{% trans "Sign up" %}</button>
             </div>
         </form>
     </section>

--- a/mapit-gb/templates/account/signup_closed.html
+++ b/mapit-gb/templates/account/signup_closed.html
@@ -1,4 +1,4 @@
-{% extends "mapit/base.html" %}
+{% extends "account/base.html" %}
 
 {% load url from compat %}
 {% load i18n %}
@@ -6,14 +6,21 @@
 {% block title %}{% trans "Sign up" %}{% endblock %}
 
 {% block content %}
-<article>
+<article id="api-docs">
     {% include 'account/_logged_in_sidebar.html' %}
-    <section>
-        <h1>{% trans "This site is in private beta" %}</h1>
+    <section class="account-form">
+        <h2>{% trans "This site is in private beta" %}</h2>
         <p>{% blocktrans %}If you have signup code you can enter it below.{% endblocktrans %}</p>
         <form method="get" action="">
-            <div><input type="text" name="code" placeholder="Your signup code..." /></div>
-            <div><input type="submit" class="btn"></div>
+            <div class="account-form__field">
+                <div class="account-form__label">Signup code</div>
+                <div class="account-form__input">
+                    <input type="text" name="code" placeholder="Your signup code..." />
+                </div>
+            </div>
+            <div class="account-form__field account-form__field--submit">
+                <input type="submit" class="btn">
+            </div>
         </form>
     </section>
 </article>

--- a/mapit-gb/templates/api_keys/api_key_detail.html
+++ b/mapit-gb/templates/api_keys/api_key_detail.html
@@ -1,0 +1,17 @@
+{% extends "account/base.html" %}
+
+{% load url from compat %}
+{% load i18n %}
+
+{% block title %}{% trans "API Key" %}{% endblock %}
+
+{% block content %}
+<article id="api-docs">
+    {% include 'account/_logged_in_sidebar.html' %}
+    <section class="account-form">
+        <h2>{% trans "API Key" %}</h2>
+        <p>Your API Key is:</p>
+        <pre>{{ api_key.key }}</pre>
+    </section>
+</article>
+{% endblock %}

--- a/mapit-gb/templates/mapit/index-usage.html
+++ b/mapit-gb/templates/mapit/index-usage.html
@@ -1,0 +1,29 @@
+<section id="usage-licence">
+
+<h3>Usage &amp; Licence</h3>
+
+<p>As a UK registered charity our legal status only allows this
+service to be used free of charge by other registered charities, or
+individuals working unpaid on non-profit projects. The free usage
+limit for non-profit users is 50,000 calls to the API per year. All
+other uses need to acquire a licence.</p>
+
+<p><a href="/licensing">Find out if you need a licence</a> or <a
+    href="mailto:enquiries&#64;mysociety.org">get in touch</a> so we
+can discuss how we can provide you with the service you require.</p>
+
+<p>To maintain quality of service for our own websites, as well as our
+API users, this service is rate limited to an average of 1 call per
+second in a rolling 3 minute period.</p>
+
+<p>We recommend that you <a href="{% url "account_signup" %}">register for an account</a>
+    and obtain an api key if you're going to use the api. Anonymous usage of
+    the API is permitted, but is rate limited to 10 calls a minute and is
+    meant for trials only.</p>
+
+<p>If you use this service, you must attribute OS/RM/ONS as per their licences.
+We also ask that all non-profit users attribute MapIt at the point of use on
+sites or apps. Attribution should use the text &ldquo;Powered by MapIt&rdquo;,
+with a link back to this page.</p>
+
+</section>

--- a/mapit-gb/templates/mapit/index.html
+++ b/mapit-gb/templates/mapit/index.html
@@ -1,0 +1,123 @@
+{% extends "mapit/base.html" %}
+{% load url from compat %}
+{% load static from staticfiles %}
+
+{% block fulltitle %}
+    MapIt : map postcodes and geographical points to administrative areas
+{% endblock %}
+
+{% block content %}
+
+    <!-- Main header -->
+    <header class="header homepage">
+        {% include "mapit/index-cross-sell.html" %}
+        <h1>Map<em>It</em><em class="mapit-type">: {% include "mapit/country.html" %}</em></h1>
+        {% include "mapit/intro.html" %}
+    </header>
+
+    <!-- Try out MapIt postcode bar -->
+    <div id="try-mapit">
+        <form method="post" action="{% url "mapit_index" %}{% if postcodes_available %}postcode{% else %}point{% endif %}/">
+            <label for="try-mapit-pc">
+                {% if postcodes_available %}Try it out, enter a postcode:
+                {% else %}Try it out, enter a lat,lon:{% endif %}
+            </label>
+            <input type="text" name="pc" id="try-mapit-pc"{% if not postcodes_available %} placeholder="latitude,longitude"{% endif %}>
+            <input class="btn" type="submit" value="Look up">
+        </form>
+    </div>
+
+    <article id="api-docs">
+
+        <header>
+
+            <h2>MapIt API</h2>
+
+            <nav class="toc">
+
+                <p>Lookups</p>
+                <ol>
+                    {% if postcodes_available %}
+                    <li><a href="#api-by_postcode">Postcode</a></li>
+                    <li><a href="#api-by_partial_postcode">Partial postcode</a></li>
+                    {% endif %}
+                    <li><a href="#api-by_point">Point</a></li>
+                    {% if postcodes_available %}
+                    <li><a href="#api-nearest">Nearest postcode</a></li>
+                    {% endif %}
+                    <li><a href="#api-by_area_id">Area</a></li>
+                    <li><a href="#api-related_areas">Related areas</a></li>
+                    <li><a href="#api-multiple_areas">Multiple areas</a></li>
+                    <li><a href="#api-generations">Generations</a></li>
+                </ol>
+
+                <p>Information</p>
+                <ul>
+                    <li><a href="#general">General information</a></li>
+                    <li><a href="#about-mapit">About MapIt</a></li>
+                    <li><a href="#usage-licence">Usage &amp; licence</a></li>
+                    <li><a href="https://github.com/mysociety/mapit">Source code</a></li>
+                    {% if country == 'GB' %}
+                    <li><a href="{% url 'mapit_changelog' %}">Changelog</a></li>
+                    {% endif %}
+                </ul>
+
+                {% if request.user.is_authenticated %}
+                    {% include 'account/_logged_in_nav.html' %}
+                {% else %}
+                    {% include 'account/_signup_nav.html' %}
+                {% endif %}
+
+            </nav>
+
+        </header>
+
+        {% include "mapit/api/intro.html" %}
+        {% if postcodes_available %}
+        {% include "mapit/api/postcode.html" %}
+        {% endif %}
+        {% include "mapit/api/point.html" %}
+        {% include "mapit/api/area.html" %}
+        {% include "mapit/api/areas.html" %}
+        {% include "mapit/api/generations.html" %}
+
+        <section id="general">
+            <h3>General information</h3>
+            <dl>
+                <dt>Format</dt>
+                <dd>
+                <p>All calls return JSON, you can generally get an HTML representation
+                by sticking .html on the end.</p>
+                <p>Whenever an area is returned from MapIt, it is as a
+                dictionary with the following keys: id, name, country, type,
+                parent_area, generation_low, generation_high, codes.</p>
+                </dd>
+                <dt>Historical areas</dt>
+                <dd>By default, calls will return active areas; for some calls
+                you may specify a previous generation to look up instead.
+                {% include "mapit/index-general-extra.html" %}
+                </dd>
+            </dl>
+        </section>
+
+        <section id="about-mapit">
+            <h3>About MapIt</h3>
+
+            <p>MapIt was written back in 2003 as a postcode lookup to power the
+            original <a href="http://www.mysociety.org/">mySociety</a> sites
+            such as <a href="http://www.writetothem.com/">WriteToThem</a>. Over
+            time it gained features such as point lookup (for
+            <a href="http://www.fixmystreet.com/">FixMyStreet</a>), and when
+            Ordnance Survey data became freely available in 2010, it was
+            rewritten and made public for the whole UK.
+
+            {% include "mapit/index-others.html" %}
+            </p>
+
+        </section>
+
+        {% include "mapit/index-usage.html" %}
+
+    </article>
+
+{% endblock %}

--- a/mapit-gb/urls.py
+++ b/mapit-gb/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     url(r'^', include('mapit.urls')),
     url(r'^admin/', include(admin.site.urls)),
     url(r"^account/", include("account.urls")),
+    url(r"^account/api_keys/", include("api_keys.urls")),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 django-mapit==1.3.1
 django-user-accounts==1.0.1
+mock==1.0.1
+mockredispy==2.9.0.10
 redis==2.10.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 django-mapit==1.3.1
 django-user-accounts==1.0.1
+redis==2.10.3

--- a/static/sass/accounts.scss
+++ b/static/sass/accounts.scss
@@ -42,6 +42,17 @@
         font-family: 'MuseoSlab500', sans-serif;
         @include border-radius(0.625em/2);
     }
+
+    .account-form__errors {
+        // Pad out the error so that it's aligned under the field when the
+        // field and label are floated next to each other
+        @media (min-width: 19em) {
+            padding-left: 8em;
+        }
+        .errorlist {
+            margin: 0;
+        }
+    }
 }
 
 .account-form__label,
@@ -50,4 +61,24 @@
 }
 .account-form__label {
     width:8em;
+}
+
+ .account-form__input--error {
+    input {
+        border-color: red;
+        // Space for the error message below
+        margin-bottom: 0.625em;
+    }
+ }
+
+.account-form__errors {
+    float: none;
+    clear: both;
+    color: red;
+    .errorlist {
+        padding: 0;
+        li {
+            list-style: none;
+        }
+    }
 }


### PR DESCRIPTION
This adds two basic management commands that interact with the redis database
that Varnish uses to perform api management.
- api_keys_restrict_api turns api key checking on and off (based on a setting
  in the django config)
- api_keys_throttle_api turns api throttling (rate limiting) on and off (again,
  based on settings in the django config)
