### PR TITLE
Move to timestamped deploy.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 .sass-cache
 
 .venv
+.static
 
 .DS_Store
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,6 +70,7 @@ Vagrant.configure(2) do |config|
 
     # Run post-deploy actions script to create a virtualenv, install the
     # python packages we need, migrate the db and generate the sass etc
+    conf/pre_deploy_actions.bash
     conf/post_deploy_actions.bash
 
     # Get the VCL from the varnish-api-key project

--- a/conf/httpd.conf-example
+++ b/conf/httpd.conf-example
@@ -6,9 +6,9 @@
 # Copyright (c) 2010 UK Citizens Online Democracy. All rights reserved.
 # Email: matthew@mysociety.org; WWW: http://www.mysociety.org
 
-WSGIDaemonProcess example.mapit.mysociety.org user=exampleuser group=examplegroup processes=5 threads=1 display-name=example.mapit.mysociety.org python-path=/data/vhost/example.mapit.mysociety.org/virtualenv-mapit/lib/python/site-packages
+WSGIDaemonProcess example.mapit.mysociety.org user=exampleuser group=examplegroup processes=5 threads=1 display-name=example.mapit.mysociety.org python-path=/data/vhost/example.mapit.mysociety.org/mapit.mysociety.org/.venv/lib/python/site-packages
 WSGIProcessGroup example.mapit.mysociety.org
 
 WSGIScriptAlias / /data/vhost/example.mapit.mysociety.org/mapit.mysociety.org/mapit_mysociety_org/wsgi.py
 
-Alias /static /data/vhost/example.mapit.mysociety.org/collected_static
+Alias /static /data/vhost/example.mapit.mysociety.org/mapit.mysociety.org/.static

--- a/conf/post_deploy_actions.bash
+++ b/conf/post_deploy_actions.bash
@@ -6,51 +6,7 @@ set -e
 # check that we are in the expected directory
 cd "$(dirname $BASH_SOURCE)"/..
 
-# Some env variables used during development seem to make things break - set
-# them back to the defaults which is what they would have on the servers.
-PYTHONDONTWRITEBYTECODE=""
-
-# create the virtual environment; we always want system packages
-virtualenv_args="--system-site-packages"
-virtualenv_dir='../virtualenv-mapit_mysociety_org'
-virtualenv_activate="$virtualenv_dir/bin/activate"
-
-if [ ! -f "$virtualenv_activate" ]
-then
-    virtualenv $virtualenv_args $virtualenv_dir
-fi
-
-source $virtualenv_activate
-
-# Upgrade pip to a secure version
-# curl -L -s https://raw.github.com/pypa/pip/master/contrib/get-pip.py | python
-# Revert to the line above once we can get a newer setuptools from Debian, or
-# pip ceases to need such a recent one.
-curl -L -s https://raw.github.com/mysociety/commonlib/master/bin/get_pip.bash | bash
-# Improve SSL behaviour
-pip install 'pyOpenSSL>=0.14'
-
-# Install all the packages
-pip install -r requirements.txt
-
-# make sure that there is no old code (the .py files may have been git deleted)
-find . -name '*.pyc' -delete
-
-# Compile CSS
-bin/mapit_make_css
+source .venv/bin/activate
 
 # get the database up to speed
 python manage.py migrate
-
-# gather all the static files in one place
-python manage.py collectstatic --noinput
-
-# Configure the default site's base url, so that link-building using the sites
-# framework works.
-python manage.py create_default_site
-
-# Make sure the Redis api key checking/throttling is set up as-per the config
-# settings
-python manage.py api_keys_restrict_api
-python manage.py api_keys_throttle_api
-python manage.py subscription_default_quota

--- a/conf/post_deploy_actions.bash
+++ b/conf/post_deploy_actions.bash
@@ -27,6 +27,8 @@ source $virtualenv_activate
 # Revert to the line above once we can get a newer setuptools from Debian, or
 # pip ceases to need such a recent one.
 curl -L -s https://raw.github.com/mysociety/commonlib/master/bin/get_pip.bash | bash
+# Improve SSL behaviour
+pip install 'pyOpenSSL>=0.14'
 
 # Install all the packages
 pip install -r requirements.txt

--- a/conf/post_deploy_actions.bash
+++ b/conf/post_deploy_actions.bash
@@ -11,12 +11,7 @@ cd "$(dirname $BASH_SOURCE)"/..
 PYTHONDONTWRITEBYTECODE=""
 
 # create the virtual environment; we always want system packages
-virtualenv_version="$(virtualenv --version)"
-virtualenv_args=""
-if [ "$(echo -e '1.7\n'$virtualenv_version | sort -V | head -1)" = '1.7' ]; then
-    virtualenv_args="--system-site-packages"
-fi
-
+virtualenv_args="--system-site-packages"
 virtualenv_dir='../virtualenv-mapit_mysociety_org'
 virtualenv_activate="$virtualenv_dir/bin/activate"
 

--- a/conf/pre_deploy_actions.bash
+++ b/conf/pre_deploy_actions.bash
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# abort on any errors
+set -e
+
+# check that we are in the expected directory
+cd "$(dirname $BASH_SOURCE)"/..
+
+# Some env variables used during development seem to make things break - set
+# them back to the defaults which is what they would have on the servers.
+PYTHONDONTWRITEBYTECODE=""
+
+# create the virtual environment; we always want system packages
+virtualenv_args="--system-site-packages"
+virtualenv_dir='.venv'
+virtualenv_activate="$virtualenv_dir/bin/activate"
+
+if [ ! -f "$virtualenv_activate" ]
+then
+    virtualenv $virtualenv_args $virtualenv_dir
+fi
+
+source $virtualenv_activate
+
+# Upgrade pip to a secure version
+# curl -L -s https://raw.github.com/pypa/pip/master/contrib/get-pip.py | python
+# Revert to the line above once we can get a newer setuptools from Debian, or
+# pip ceases to need such a recent one.
+curl -L -s https://raw.github.com/mysociety/commonlib/master/bin/get_pip.bash | bash
+# Improve SSL behaviour
+pip install 'pyOpenSSL>=0.14'
+
+# Install all the packages
+pip install -r requirements.txt
+
+# make sure that there is no old code (the .py files may have been git deleted)
+find . -name '*.pyc' -delete
+
+# Compile CSS
+bin/mapit_make_css
+
+# gather all the static files in one place
+python manage.py collectstatic --noinput --link
+
+# Configure the default site's base url, so that link-building using the sites
+# framework works.
+python manage.py create_default_site
+
+# Make sure the Redis api key checking/throttling is set up as-per the config
+# settings
+python manage.py api_keys_restrict_api
+python manage.py api_keys_throttle_api
+python manage.py subscription_default_quota

--- a/mapit_mysociety_org/mapit_settings.py
+++ b/mapit_mysociety_org/mapit_settings.py
@@ -151,7 +151,7 @@ MEDIA_URL = ''
 # Don't put anything in this directory yourself; store your static files
 # in apps' "static/" subdirectories and in STATICFILES_DIRS.
 # Example: "/var/www/example.com/static/"
-STATIC_ROOT = os.path.join(PARENT_DIR, 'collected_static')
+STATIC_ROOT = os.path.join(BASE_DIR, '.static')
 
 # URL prefix for static files.
 # Example: "http://example.com/static/", "http://static.example.com/"


### PR DESCRIPTION
Set up a new virtualenv on each deploy (it will use cached wheels etc after the first time so it isn't bad), and make sure SSL warnings are dealt with.

This reduces any front-end downtime to only running `migrate`, everything else that used to be done while the site was down (check virtualenv, collectstatic, etc), is done whilst the site remains up. It'd be good if we could even skip migrate given we won't need to run it often, but this is still a big improvement.