### PR TITLE
Fix file input styling

### DIFF
--- a/static/sass/_accounts.scss
+++ b/static/sass/_accounts.scss
@@ -1,9 +1,15 @@
 .account-form__field {
     margin-bottom: 1em;
 
-    input {
+    input[type="text"],
+    input[type="email"],
+    input[type="password"] {
         @extend .form-control;
     }
+}
+
+input[type="file"] {
+    line-height: 1em;
 }
 
 .account-form__field--error {


### PR DESCRIPTION
The file input on the bulk upload page looked a bit weird because it was inheriting the .form-control styling meant for text inputs. Now it doesn’t. 

Also, line-height:1em fixes a visual bug on Mac.

Fixes #47.

**Very un-exciting screenshot:**
![screen shot 2017-04-25 at 17 33 52](https://cloud.githubusercontent.com/assets/739624/25396692/6f2d3d36-29dd-11e7-8823-d2c1bb68b0c4.png)
