### PR TITLE
Update contact.html

### DIFF
--- a/mapit_mysociety_org/templates/mapit/contact.html
+++ b/mapit_mysociety_org/templates/mapit/contact.html
@@ -8,12 +8,7 @@
 
 <h1>Contact us</h1>
 
-<h2>Technical queries</h2>
-<p>If you have questions about how MapIt works, or the data, drop a line to
-<a href="mailto:mapit&#64;mysociety.org">mapit&#64;mysociety.org</a>.</p>
-
-<h2>Account queries</h2>
-<p>Problems with your subscription or payment? Email
-<a href="mailto:enquiries&#64;mysociety.org">enquiries&#64;mysociety.org</a> and we'll help you out.
+<p>Problems? Questions? Drop a line to
+<a href="mailto:mapit&#64;mysociety.org">mapit&#64;mysociety.org</a> and we’ll help you out.</p>
 
 {% endblock %}


### PR DESCRIPTION
Based on the emails we've had since self-service launched, mapit@ is going to be the best email address to handle pretty much all contact (at least initially), so, remove the enquiries address from the page.