### PR TITLE
Ignore Stripe plans/coupons that aren't ours.

### DIFF
--- a/mapit_mysociety_org/management/commands/add_mapit_user.py
+++ b/mapit_mysociety_org/management/commands/add_mapit_user.py
@@ -16,9 +16,9 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         plans = stripe.Plan.list()
-        plan_ids = [plan['id'] for plan in plans.data]
+        plan_ids = [plan['id'] for plan in plans.data if plan['id'].startswith('mapit')]
         coupons = stripe.Coupon.list()
-        self.coupon_ids = [coupon['id'] for coupon in coupons]
+        self.coupon_ids = [coupon['id'] for coupon in coupons if coupon['id'].startswith('charitable')]
         parser.add_argument('--email', required=True)
         parser.add_argument('--plan', choices=plan_ids, required=True)
         parser.add_argument('--coupon', help='Existing coupons: ' + ', '.join(self.coupon_ids))

--- a/subscriptions/tests.py
+++ b/subscriptions/tests.py
@@ -354,7 +354,7 @@ class SubscriptionHookViewTest(PatchedStripeMixin, UserTestCase):
         event = {
             'id': 'EVENT-ID-FAILED',
             'type': 'invoice.payment_failed',
-            'data': {'object': {'id': 'INVOICE-ID', 'customer': 'CUSTOMER-ID', 'next_payment_attempt': 1234567890}}
+            'data': {'object': {'id': 'INVOICE-ID', 'customer': 'CUSTOMER-ID', 'next_payment_attempt': 1234567890, 'subscription': 'SUBSCRIPTION-ID'}}
         }
         self.MockStripe.Event.retrieve.return_value = convert_to_stripe_object(event, None, None)
         self.post_to_hook('EVENT-ID-FAILED')
@@ -365,7 +365,7 @@ class SubscriptionHookViewTest(PatchedStripeMixin, UserTestCase):
         event = {
             'id': 'EVENT-ID-FAILED',
             'type': 'invoice.payment_failed',
-            'data': {'object': {'id': 'INVOICE-ID', 'customer': 'CUSTOMER-ID', 'next_payment_attempt': None}}
+            'data': {'object': {'id': 'INVOICE-ID', 'customer': 'CUSTOMER-ID', 'next_payment_attempt': None, 'subscription': 'SUBSCRIPTION-ID'}}
         }
         self.MockStripe.Event.retrieve.return_value = convert_to_stripe_object(event, None, None)
         self.post_to_hook('EVENT-ID-FAILED')


### PR DESCRIPTION
If Stripe sends us an event for a plan that doesn't start with 'mapit',
ignore it; in the command line script, exclude any non-MapIt coupons or
plans. Fixes #69. Fixes #71.