### PR TITLE
Fix middleware against mapit master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
     - CFLAGS="-O0"
   matrix:
     - TOXENV=flake8
-    - TOXENV=py27-1.8
     - TOXENV=py27-1.11
 
 install:

--- a/mapit_mysociety_org/mapit_settings.py
+++ b/mapit_mysociety_org/mapit_settings.py
@@ -178,14 +178,13 @@ STATICFILES_FINDERS = (
 # similar ETag code in CommonMiddleware.
 USE_ETAGS = False
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.gzip.GZipMiddleware',
     'django.middleware.http.ConditionalGetMiddleware',
     'django.middleware.cache.UpdateCacheMiddleware',
-    'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.cache.FetchFromCacheMiddleware',
     'mapit.middleware.JSONPMiddleware',
@@ -199,11 +198,6 @@ WSGI_APPLICATION = 'project.wsgi.application'
 
 TEMPLATES = [{
     'BACKEND': 'django.template.backends.django.DjangoTemplates',
-    'DIRS': (
-        # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
-        # Always use forward slashes, even on Windows.
-        # Don't forget to use absolute paths, not relative paths.
-    ),
     'OPTIONS': {
         'context_processors': (
             'django.template.context_processors.request',

--- a/mapit_mysociety_org/settings.py
+++ b/mapit_mysociety_org/settings.py
@@ -3,7 +3,7 @@ import sys
 
 # Import MapIt's settings (first time to quiet flake8)
 from mapit_settings import (
-    config, INSTALLED_APPS, TEMPLATES, MIDDLEWARE_CLASSES, STATICFILES_DIRS, BASE_DIR, MAPIT_RATE_LIMIT, PARENT_DIR)
+    config, INSTALLED_APPS, TEMPLATES, MIDDLEWARE, STATICFILES_DIRS, BASE_DIR, MAPIT_RATE_LIMIT, PARENT_DIR)
 from mapit_settings import *  # noqa
 
 # Update a couple of things to suit our changes
@@ -22,7 +22,7 @@ TEMPLATES[0]['OPTIONS']['context_processors'] = old_context_processors + (
     'mapit_mysociety_org.context_processors.add_settings',
 )
 
-MIDDLEWARE_CLASSES.extend([
+MIDDLEWARE.extend([
     'django.middleware.csrf.CsrfViewMiddleware',
     "account.middleware.LocaleMiddleware",
     "account.middleware.TimezoneMiddleware",

--- a/mapit_mysociety_org/views.py
+++ b/mapit_mysociety_org/views.py
@@ -38,6 +38,7 @@ class SignupView(SubscriptionUpdateMixin, account.views.SignupView):
     """ Override account.views.SignupView to use our email-only SignupForm """
 
     form_class = forms.SignupForm
+    identifier_field = 'email'
 
     def __init__(self, *args, **kwargs):
         self.messages.pop('email_confirmation_sent', None)

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,6 +1,6 @@
 psycopg2 >= 2.5.4
 -e git://github.com/mysociety/mapit.git@master#egg=django-mapit
-django-user-accounts==1.3.1
+django-user-accounts==2.0.3
 django-mailer==1.2.2
 mock==1.3.0
 mockredispy==2.9.0.12

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = flake8, py{27}-{1.8,1.11}
+envlist = flake8, py{27}-1.11
 
 [testenv]
 commands =
@@ -9,7 +9,6 @@ commands =
 deps =
     flake8: flake8
     py{27,35}: -r{toxinidir}/requirements-base.txt
-    1.8: Django>=1.8,<1.9
     1.11: Django>=1.11,<2.0
     2.0: Django>=2.0,<2.1
 


### PR DESCRIPTION
mapit master only supports Django 1.11+ now, so its middleware only supports using `MIDDLEWARE`, not `MIDDLEWARE_CLASSES`. Switch, and upgrade django-user-accounts to gain compatibility there too.