### PR TITLE
Add replica database vars to example config

### DIFF
--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -10,6 +10,9 @@ MAPIT_DB_USER: 'mapit'
 MAPIT_DB_PASS: 'mapit'
 MAPIT_DB_HOST: 'localhost'
 MAPIT_DB_PORT: '5432'
+# Optional read-only replica database
+MAPIT_DB_RO_HOST: 'replica'
+MAPIT_DB_RO_PORT: '5433'
 
 REDIS_DB_HOST: 'localhost'
 REDIS_DB_PORT: 6379

--- a/mapit_mysociety_org/mapit_settings.py
+++ b/mapit_mysociety_org/mapit_settings.py
@@ -32,12 +32,12 @@ except:
 # WGS84. Optional, defaults to 4326.
 MAPIT_AREA_SRID = int(config.get('AREA_SRID', 4326))
 
-# Country is currently one of GB, NO, KE or ZA. Optional; country specific things
-# won't happen if not set.
+# Country is currently one of GB, NO, IT, KE, SA, or ZA.
+# Optional; country specific things won't happen if not set.
 MAPIT_COUNTRY = config.get('COUNTRY', '')
 
-# A list of IP addresses or User Agents that should be excluded from rate
-# limiting. Optional.
+# A dictionary of IP addresses, User Agents, or functions that should be
+# excluded from rate limiting. Optional.
 MAPIT_RATE_LIMIT = config.get('RATE_LIMIT', {})
 
 # A GA code for analytics
@@ -116,10 +116,6 @@ elif MAPIT_COUNTRY == 'IT':
 elif MAPIT_COUNTRY == 'ZA':
     TIME_ZONE = 'Africa/Johannesburg'
     LANGUAGE_CODE = 'en-za'
-    POSTCODES_AVAILABLE = PARTIAL_POSTCODES_AVAILABLE = False
-elif MAPIT_COUNTRY == 'Global':
-    TIME_ZONE = 'Europe/London'
-    LANGUAGE_CODE = 'en'
     POSTCODES_AVAILABLE = PARTIAL_POSTCODES_AVAILABLE = False
 else:
     TIME_ZONE = 'Europe/London'

--- a/mapit_mysociety_org/middleware.py
+++ b/mapit_mysociety_org/middleware.py
@@ -1,0 +1,22 @@
+from .multidb import use_primary
+
+READ_METHODS = frozenset(['GET', 'HEAD', 'OPTIONS', 'TRACE'])
+
+
+def force_primary_middleware(get_response):
+    """On a non-read request (e.g. POST), always use the primary database, and
+    set a short-lived cookie. Then on any request made including that cookie,
+    also always use the primary database. This is so we don't need to worry
+    about any replication lag for reads made immediately after writes, because
+    we force those reads to go to the primary."""
+    def middleware(request):
+        use_primary('primary_forced' in request.COOKIES or request.method not in READ_METHODS)
+
+        response = get_response(request)
+
+        if request.method not in READ_METHODS:
+            response.set_cookie('primary_forced', value='y', max_age=10)
+
+        return response
+
+    return middleware

--- a/mapit_mysociety_org/multidb.py
+++ b/mapit_mysociety_org/multidb.py
@@ -1,0 +1,16 @@
+"""
+A getter/setter for a thread-local variable for using the primary database.
+"""
+
+import threading
+
+_locals = threading.local()
+
+
+def use_primary(val=None):
+    """If passed no argument, return the current value (or False if unset);
+    if passed an argument, set the variable to that."""
+    if val is None:
+        return getattr(_locals, 'primary', False)
+    else:
+        _locals.primary = val


### PR DESCRIPTION
Adds examples for configuring a read-only replica database to the example configuration file, and necessary code to use it.