### PR TITLE
Add paragraph to explain split postcodes

### DIFF
--- a/mapit_mysociety_org/templates/mapit/overview.html
+++ b/mapit_mysociety_org/templates/mapit/overview.html
@@ -173,6 +173,16 @@
         make them available in some manner, but they are not published in the
         same format as the normal data.</p>
 
+        <h4>Restrictions</h4>
+
+        <p>
+            Note that MapIt works by matching the <i>centre point</i> of the
+            given postcode to the boundaries it sits within. In a few rare cases
+            (affecting perhaps half the residents in approximately 0.2% of
+            postcode areas), where a postcode area straddles a boundary, this
+            will result in a return of the neighbouring ward or constituency.
+        </p>
+
     </section>
 
 {% endblock %}

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,6 +1,7 @@
 psycopg2 >= 2.5.4
 -e git://github.com/mysociety/mapit.git@master#egg=django-mapit
 django-user-accounts==2.0.3
+django-appconf==1.0.3
 django-mailer==1.2.2
 mock==1.3.0
 mockredispy==2.9.0.12


### PR DESCRIPTION
Some postcodes straddle administrative boundaries and MapIt may return the wrong result. This adds the proposed explanatory text from #102.

Fixes #102.