### PR TITLE
Remove django-apptemplates.

### DIFF
--- a/mapit_mysociety_org/mapit_settings.py
+++ b/mapit_mysociety_org/mapit_settings.py
@@ -204,7 +204,6 @@ TEMPLATES = [{
         ),
         # List of callables that know how to import templates from various sources.
         'loaders': (
-            'apptemplates.Loader',
             'django.template.loaders.filesystem.Loader',
             'django.template.loaders.app_directories.Loader',
         ),

--- a/mapit_mysociety_org/templates/mapit/area.html
+++ b/mapit_mysociety_org/templates/mapit/area.html
@@ -1,4 +1,4 @@
-{% extends "mapit:mapit/area.html" %}
+{% extends "mapit/area.html" %}
 {% load i18n %}
 
 {% block area_info_extra %}

--- a/mapit_mysociety_org/templates/mapit/base.html
+++ b/mapit_mysociety_org/templates/mapit/base.html
@@ -1,4 +1,4 @@
-{% extends "mapit:mapit/base.html" %}
+{% extends "mapit/base.html" %}
 
 {% load static %}
 

--- a/mapit_mysociety_org/templates/mapit/postcode.html
+++ b/mapit_mysociety_org/templates/mapit/postcode.html
@@ -1,4 +1,4 @@
-{% extends "mapit:mapit/postcode.html" %}
+{% extends "mapit/postcode.html" %}
 {% load i18n %}
 
 {% block area_info_extra %}

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -5,7 +5,6 @@ django-mailer==1.2.2
 mock==1.3.0
 mockredispy==2.9.0.12
 redis==2.10.5
-django-apptemplates==1.4
 stripe==2.35.0
 six
 


### PR DESCRIPTION
Recursive templates have been supported since Django 1.9,
though only [documented in 3.1](https://docs.djangoproject.com/en/3.1/howto/overriding-templates/#extending-an-overridden-template)

Includes bits of the python3 branch which I should tidy up and PR, not sure why it wasn't, probably look at that first.