### PR TITLE
Move python packages

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6]
-        thing-to-test: [flake8, 1.11, 2.2, 3.1, 3.2]
+        thing-to-test: [flake8, 1.11, 2.2, 3.2]
         include:
           - python-version: 2.7
             thing-to-test: 1.11

--- a/conf/packages
+++ b/conf/packages
@@ -1,15 +1,7 @@
 postgresql-client
-libgdal1 | libgdal20
 memcached
-python-virtualenv
+virtualenv
 libapache2-mod-wsgi
-
-libffi-dev
-libssl-dev
 python-dev
-
-python-psycopg2
-python-shapely
-python-yaml
-python-memcache
-python-gdal
+python3-dev
+libgdal-dev

--- a/conf/pre_deploy_actions.bash
+++ b/conf/pre_deploy_actions.bash
@@ -10,8 +10,8 @@ cd "$(dirname $BASH_SOURCE)"/..
 # them back to the defaults which is what they would have on the servers.
 PYTHONDONTWRITEBYTECODE=""
 
-# create the virtual environment; we always want system packages
-virtualenv_args="--system-site-packages"
+# create the virtual environment
+virtualenv_args=""
 virtualenv_dir='.venv'
 virtualenv_activate="$virtualenv_dir/bin/activate"
 
@@ -22,15 +22,13 @@ fi
 
 source $virtualenv_activate
 
-# Upgrade pip to a secure version
-# curl -L -s https://raw.github.com/pypa/pip/master/contrib/get-pip.py | python
-# Revert to the line above once we can get a newer setuptools from Debian, or
-# pip ceases to need such a recent one.
-curl -L -s https://raw.github.com/mysociety/commonlib/master/bin/get_pip.bash | bash
-# Improve SSL behaviour
-pip install 'pyOpenSSL>=0.14'
+# Install GDAL, correct version, right headers
+gdal_version=$(gdal-config --version)
+# stretch version of GDAL doesn't have matching pypi version
+if [ $gdal_version = "2.1.2" ]; then gdal_version="2.1.3"; fi
+C_INCLUDE_PATH=/usr/include/gdal CPLUS_INCLUDE_PATH=/usr/include/gdal pip install GDAL==$gdal_version
 
-# Install all the packages
+# Install all the (other) packages
 pip install -r requirements.txt
 
 # make sure that there is no old code (the .py files may have been git deleted)

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -7,6 +7,10 @@ redis==2.10.5
 stripe==2.35.0
 six
 
+Shapely==1.7.1
+PyYAML==5.3.1
+python-memcached==1.59
+
 # Bulk lookup
 xlrd<2
 defusedxml==0.5.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,6 +1,5 @@
 psycopg2 >= 2.5.4
 -e git+https://github.com/mysociety/mapit.git@master#egg=django-mapit
-django-appconf==1.0.3
 django-mailer==1.2.2
 mock==1.3.0
 mockredispy==2.9.0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django==1.11.29
 django-formtools==2.1
 django-user-accounts==2.0.3
+django-appconf==1.0.3
 -r requirements-base.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = flake8, py{27,36}-1.11, py36-{2.2,3.1,3.2}
+envlist = flake8, py27-1.11, py36-{1.11,2.2,3.2}
 
 [testenv]
 commands =
@@ -13,11 +13,12 @@ deps =
     1.11: Django>=1.11,<2.0
     1.11: django-formtools==2.1
     1.11: django-user-accounts==2.0.3
+    1.11: django-appconf==1.0.3
     2.2: Django>=2.2,<3.0
-    3.1: Django>=3.1,<3.2
-    3.2: Django==3.2b1
-    2.2,3.1,3.2: django-formtools==2.2
-    2.2,3.1,3.2: django-user-accounts==3.0.2
+    3.2: Django>=3.2,<4.0
+    2.2,3.2: django-formtools==2.3
+    2.2,3.2: django-user-accounts==3.0.4
+    2.2,3.2: django-appconf==1.0.4
 
 [testenv:flake8]
 skip_install = True
@@ -32,5 +33,4 @@ THING_TO_TEST =
   flake8: flake8
   1.11: 1.11
   2.2: 2.2
-  3.1: 3.1
   3.2: 3.2


### PR DESCRIPTION
This moves the python packages out of conf/packages into requirements, and the necessary changes thereby.
It does add python3-dev to conf/packages in preparation, but that wasn't strictly needed at this point.
(And tidies up for Django 3.2 being released.)