### PR TITLE
Add support for Redis Sentinel

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6]
-        thing-to-test: [flake8, 1.11, 2.2, 3.1, 3.2]
+        thing-to-test: [flake8, 1.11, 2.2, 3.2]
         include:
           - python-version: 2.7
             thing-to-test: 1.11

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -29,13 +29,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6]
-        thing-to-test: [flake8, 1.11, 2.2, 3.2]
-        include:
-          - python-version: 2.7
-            thing-to-test: 1.11
-          - python-version: 2.7
-            thing-to-test: flake8
+        python-version: [3.7, 3.9]
+        thing-to-test: [flake8, 2.2, 3.2]
 
     steps:
     - uses: actions/checkout@v2

--- a/api_keys/models.py
+++ b/api_keys/models.py
@@ -5,14 +5,12 @@ from django.db import models
 from django.dispatch import receiver
 from django.conf import settings
 
-from six import python_2_unicode_compatible
 from account.signals import user_signed_up
 
 from .utils import redis_connection
 
 
 # Inspired by https://github.com/CIGIHub/django-simple-api-key
-@python_2_unicode_compatible
 class APIKey(models.Model):
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,

--- a/api_keys/tests.py
+++ b/api_keys/tests.py
@@ -26,9 +26,15 @@ class PatchedRedisTestCase(TestCase):
             mock_strict_redis_client
         )
         self.redis_patcher.start()
+        self.sentinel_patcher = patch(
+            'api_keys.utils.Sentinel',
+            **{'return_value.master_for.return_value': mock_strict_redis_client()}
+        )
+        self.sentinel_patcher.start()
 
     def tearDown(self):
         self.redis_patcher.stop()
+        self.sentinel_patcher.stop()
 
 
 class SignalsTest(PatchedRedisTestCase):

--- a/api_keys/tests.py
+++ b/api_keys/tests.py
@@ -1,4 +1,4 @@
-from six import StringIO
+from io import StringIO
 
 from mock import patch
 from mockredis import mock_strict_redis_client

--- a/api_keys/urls.py
+++ b/api_keys/urls.py
@@ -1,21 +1,21 @@
-from django.conf.urls import url
+from django.urls import path
 from django.contrib.auth.decorators import login_required
 
 from .views import APIKeyListView, APIKeyDeleteView, APIKeyCreateView
 
 urlpatterns = [
-    url(
-        r'^keys',
+    path(
+        'keys',
         login_required(APIKeyListView.as_view()),
         name="api_keys_keys"
     ),
-    url(
-        r'^create',
+    path(
+        'create',
         login_required(APIKeyCreateView.as_view()),
         name="api_keys_create_key"
     ),
-    url(
-        r'^(?P<pk>\d+)/delete',
+    path(
+        '<int:pk>/delete',
         login_required(APIKeyDeleteView.as_view()),
         name="api_keys_delete_key"
     )

--- a/bulk_lookup/csv.py
+++ b/bulk_lookup/csv.py
@@ -3,12 +3,11 @@ import mmap
 import pyexcel
 from pyexcel._compact import zip_longest
 import defusedxml
-from six import Iterator, PY2
 
 defusedxml.defuse_stdlib()
 
 
-class file_without_nulls_or_cp1252(Iterator):
+class file_without_nulls_or_cp1252(object):
     """An object that behaves like a provided file object,
     but strips any NULL bytes when read() is called, and
     spots Windows-1252 lines."""
@@ -45,8 +44,6 @@ class file_without_nulls_or_cp1252(Iterator):
         except UnicodeDecodeError:
             # ...Assume Windows 1252
             data = data.decode('cp1252')
-        if PY2:
-            data = data.encode('utf-8')
         return data
 
     def read(self, *args):
@@ -64,7 +61,7 @@ class file_without_nulls_or_cp1252(Iterator):
         return data
 
 
-class PyExcelReader(Iterator):
+class PyExcelReader(object):
     # Set up an iterator for reading in a CSV/XLS/XLSX/ODS file
     def __init__(self, file_field):
         self._fieldnames = None

--- a/bulk_lookup/csv.py
+++ b/bulk_lookup/csv.py
@@ -72,6 +72,8 @@ class PyExcelReader(object):
         # The XLS reader doesn't accept a stream, but does accept an mmap file...
         if ext in ('xls', 'xlsx'):
             kwargs['file_content'] = mmap.mmap(file_field.fileno(), 0, access=mmap.ACCESS_READ)
+            if ext == 'xlsx':
+                kwargs['library'] = 'pyexcel-xlsx'
         elif ext == 'csv':
             kwargs['file_stream'] = file_without_nulls_or_cp1252(file_field)
         else:  # ODS

--- a/bulk_lookup/forms.py
+++ b/bulk_lookup/forms.py
@@ -3,7 +3,7 @@
 import re
 from django import forms
 from django.utils.crypto import get_random_string
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 
 import stripe
 from ukpostcodeutils.validation import is_valid_postcode
@@ -12,7 +12,7 @@ from .models import OutputOption
 
 
 def clean_postcode(pc):
-    return re.sub('[^A-Z0-9]', '', smart_text(pc).upper())
+    return re.sub('[^A-Z0-9]', '', smart_str(pc).upper())
 
 
 class CSVForm(forms.Form):
@@ -128,7 +128,7 @@ class PersonalDetailsForm(forms.Form):
         super(PersonalDetailsForm, self).clean()
         # If we're doing this for free
         if self.free:
-            self.cleaned_data['charge_id'] = 'r_%s' % get_random_string()
+            self.cleaned_data['charge_id'] = 'r_%s' % get_random_string(12)
         elif not self.cleaned_data['charge_id']:
             raise forms.ValidationError("You need to pay for the lookup")
         else:

--- a/bulk_lookup/models.py
+++ b/bulk_lookup/models.py
@@ -47,7 +47,7 @@ def output_file_upload_to(instance, filename):
 
 
 def random_folder_path(base_folder, filename):
-    random_folder = get_random_string()
+    random_folder = get_random_string(12)
     return os.path.join(base_folder, random_folder, filename)
 
 

--- a/bulk_lookup/tests.py
+++ b/bulk_lookup/tests.py
@@ -1,5 +1,5 @@
 import os
-from six import StringIO, BytesIO
+from io import StringIO, BytesIO
 
 from django.core.management import call_command
 from django.core.files.base import ContentFile, File

--- a/bulk_lookup/urls.py
+++ b/bulk_lookup/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import url
+from django.urls import path
 
 from .views import AjaxConfirmView, WizardView, FinishedView
 
 urlpatterns = [
-    url(r'^$', WizardView.as_view(), name='home'),
-    url(r'^ajax-confirm$', AjaxConfirmView, name='ajax-confirm'),
-    url(r'^(?P<pk>\d+)/(?P<token>.+)$', FinishedView.as_view(), name='finished'),
+    path('', WizardView.as_view(), name='home'),
+    path('ajax-confirm', AjaxConfirmView, name='ajax-confirm'),
+    path('<int:pk>/<token>', FinishedView.as_view(), name='finished'),
 ]

--- a/bulk_lookup/views.py
+++ b/bulk_lookup/views.py
@@ -5,7 +5,7 @@ from django.core.exceptions import PermissionDenied
 from django.core.files.storage import FileSystemStorage
 from django.shortcuts import redirect
 from django.views.generic import DetailView
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from formtools.wizard.views import SessionWizardView
 import stripe
 
@@ -81,7 +81,7 @@ class WizardView(NeverCacheMixin, StripeObjectMixin, SessionWizardView):
         if step == 'postcode_field':
             bulk_lookup = self.get_cleaned_csv_data
             for choice in bulk_lookup.field_names:
-                if re.match(r'post(\s)*code', force_text(choice), flags=re.IGNORECASE):
+                if re.match(r'post(\s)*code', force_str(choice), flags=re.IGNORECASE):
                     initial['postcode_field'] = choice
                     break
         elif step == 'personal_details':

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -14,10 +14,24 @@ MAPIT_DB_PORT: '5432'
 MAPIT_DB_RO_HOST: 'replica'
 MAPIT_DB_RO_PORT: '5433'
 
+# Connection details for Redis.
+# Note that REDIS_DB_HOST and REDIS_DB_PORT will be ignored
+# if REDIS_SENTINEL_HOSTS is set as the connection to the
+# Redis primary will be mediated by Sentinel.
+# REDIS_DB_NUMBER and REDIS_DB_PASSWORD will be used in either
+# case when making the connection to the primary.
 REDIS_DB_HOST: 'localhost'
 REDIS_DB_PORT: 6379
 REDIS_DB_NUMBER: 0
 REDIS_DB_PASSWORD: null
+# REDIS_SENTINEL_HOSTS should be a dict of "'host': port" pairs.
+# If you don't want to use Sentinel, set it to null.
+REDIS_SENTINEL_HOSTS:
+  'localhost': 26379
+# Note that this will not be used unless REDIS_SENTINEL_HOSTS is set.
+# It refers to the set of Redis hosts Sentinel should return connection
+# details for.
+REDIS_SENTINEL_SET: data
 
 # Country is currently one of GB, NO, or KE. Optional; country specific things won't happen if not set.
 COUNTRY: 'GB'

--- a/conf/packages
+++ b/conf/packages
@@ -1,15 +1,7 @@
 postgresql-client
-libgdal1 | libgdal20
 memcached
-python-virtualenv
+virtualenv
 libapache2-mod-wsgi
-
-libffi-dev
-libssl-dev
 python-dev
-
-python-psycopg2
-python-shapely
-python-yaml
-python-memcache
-python-gdal
+python3-dev
+libgdal-dev

--- a/conf/packages
+++ b/conf/packages
@@ -1,7 +1,5 @@
 postgresql-client
 memcached
-virtualenv
-libapache2-mod-wsgi
-python-dev
+libapache2-mod-wsgi-py3
 python3-dev
 libgdal-dev

--- a/conf/pre_deploy_actions.bash
+++ b/conf/pre_deploy_actions.bash
@@ -10,8 +10,8 @@ cd "$(dirname $BASH_SOURCE)"/..
 # them back to the defaults which is what they would have on the servers.
 PYTHONDONTWRITEBYTECODE=""
 
-# create the virtual environment; we always want system packages
-virtualenv_args="--system-site-packages"
+# create the virtual environment
+virtualenv_args=""
 virtualenv_dir='.venv'
 virtualenv_activate="$virtualenv_dir/bin/activate"
 
@@ -22,15 +22,13 @@ fi
 
 source $virtualenv_activate
 
-# Upgrade pip to a secure version
-# curl -L -s https://raw.github.com/pypa/pip/master/contrib/get-pip.py | python
-# Revert to the line above once we can get a newer setuptools from Debian, or
-# pip ceases to need such a recent one.
-curl -L -s https://raw.github.com/mysociety/commonlib/master/bin/get_pip.bash | bash
-# Improve SSL behaviour
-pip install 'pyOpenSSL>=0.14'
+# Install GDAL, correct version, right headers
+gdal_version=$(gdal-config --version)
+# stretch version of GDAL doesn't have matching pypi version
+if [ $gdal_version = "2.1.2" ]; then gdal_version="2.1.3"; fi
+C_INCLUDE_PATH=/usr/include/gdal CPLUS_INCLUDE_PATH=/usr/include/gdal pip install GDAL==$gdal_version
 
-# Install all the packages
+# Install all the (other) packages
 pip install -r requirements.txt
 
 # make sure that there is no old code (the .py files may have been git deleted)

--- a/conf/pre_deploy_actions.bash
+++ b/conf/pre_deploy_actions.bash
@@ -11,13 +11,12 @@ cd "$(dirname $BASH_SOURCE)"/..
 PYTHONDONTWRITEBYTECODE=""
 
 # create the virtual environment
-virtualenv_args=""
 virtualenv_dir='.venv'
 virtualenv_activate="$virtualenv_dir/bin/activate"
 
 if [ ! -f "$virtualenv_activate" ]
 then
-    virtualenv $virtualenv_args $virtualenv_dir
+    python3 -m venv $virtualenv_dir
 fi
 
 source $virtualenv_activate

--- a/conf/pre_deploy_actions.bash
+++ b/conf/pre_deploy_actions.bash
@@ -21,11 +21,12 @@ fi
 
 source $virtualenv_activate
 
+# Install Wheel
+pip install wheel
+
 # Install GDAL, correct version, right headers
 gdal_version=$(gdal-config --version)
-# stretch version of GDAL doesn't have matching pypi version
-if [ $gdal_version = "2.1.2" ]; then gdal_version="2.1.3"; fi
-C_INCLUDE_PATH=/usr/include/gdal CPLUS_INCLUDE_PATH=/usr/include/gdal pip install GDAL==$gdal_version
+pip install GDAL==$gdal_version
 
 # Install all the (other) packages
 pip install -r requirements.txt

--- a/mapit_mysociety_org/management/commands/create_default_site.py
+++ b/mapit_mysociety_org/management/commands/create_default_site.py
@@ -1,4 +1,4 @@
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings

--- a/mapit_mysociety_org/mapit_settings.py
+++ b/mapit_mysociety_org/mapit_settings.py
@@ -1,16 +1,6 @@
+import importlib
 import os
-import sys
 import yaml
-
-if sys.version_info[:2] >= (3, 4):
-    import importlib
-    find_module = lambda c: importlib.machinery.PathFinder.find_spec(c)  # noqa
-elif sys.version_info[:2] >= (3, 1):
-    import importlib
-    find_module = lambda c: importlib.machinery.PathFinder.find_module(c)  # noqa
-else:
-    import imp
-    find_module = lambda c: imp.find_module(c)  # noqa
 
 # Path to here is something like
 # .../<repo>/<project_name>/settings.py
@@ -234,7 +224,7 @@ INSTALLED_APPS = [
 if MAPIT_COUNTRY:
     try:
         c = 'mapit_%s' % MAPIT_COUNTRY.lower()
-        find_module(c)
+        importlib.machinery.PathFinder.find_spec(c)
         # Put before 'mapit', so country templates take precedence
         INSTALLED_APPS.insert(INSTALLED_APPS.index('mapit'), c)
     except:

--- a/mapit_mysociety_org/middleware.py
+++ b/mapit_mysociety_org/middleware.py
@@ -1,6 +1,5 @@
 from functools import partial
 from django.utils.encoding import force_bytes
-from six.moves import map
 from .multidb import use_primary
 from api_keys.models import APIKey
 

--- a/mapit_mysociety_org/settings.py
+++ b/mapit_mysociety_org/settings.py
@@ -50,6 +50,8 @@ if config.get('MAPIT_DB_RO_HOST', '') and 'test' not in sys.argv:
     DATABASE_ROUTERS = ['mapit_mysociety_org.settings.PrimaryReplicaRouter']
     MIDDLEWARE.insert(0, 'mapit_mysociety_org.middleware.force_primary_middleware')
 
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 INSTALLED_APPS.extend(['django.contrib.sites', 'account', 'mailer', 'api_keys', 'subscriptions', 'bulk_lookup'])
 
 # Insert our project app before mapit and mapit_gb so that the templates

--- a/mapit_mysociety_org/settings.py
+++ b/mapit_mysociety_org/settings.py
@@ -117,6 +117,8 @@ REDIS_DB_HOST = config.get('REDIS_DB_HOST')
 REDIS_DB_PORT = config.get('REDIS_DB_PORT')
 REDIS_DB_NUMBER = config.get('REDIS_DB_NUMBER')
 REDIS_DB_PASSWORD = config.get('REDIS_DB_PASSWORD')
+REDIS_SENTINEL_HOSTS = config.get('REDIS_SENTINEL_HOSTS', None)
+REDIS_SENTINEL_SET = config.get('REDIS_SENTINEL_SET')
 
 EMAIL_BACKEND = "mailer.backend.DbBackend"
 # Configurable email port, to make it easier to develop email sending

--- a/mapit_mysociety_org/tests.py
+++ b/mapit_mysociety_org/tests.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import re
-from six import StringIO
+from io import StringIO
 from mock import patch
 
 from django.contrib.auth.models import User

--- a/mapit_mysociety_org/urls.py
+++ b/mapit_mysociety_org/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.contrib import admin
 from django.views.generic.base import RedirectView
 
@@ -7,26 +7,26 @@ from django.shortcuts import render
 from .views import LoginView, LogoutView, SignupView, ConfirmEmailView
 
 urlpatterns = [
-    url(r'^changelog$', render, {'template_name': 'changelog.html'}, 'mapit_changelog'),
-    url(r'^', include('mapit.urls')),
-    url(r'^contact$', render, {'template_name': 'mapit/contact.html'}, 'mapit_contact'),
-    url(r'^pricing/', render, {'template_name': 'pricing.html'}, 'mapit_pricing'),
-    url(r'^legal/', render, {'template_name': 'mapit/licensing.html'}, 'mapit_legal'),
-    url(r'^privacy/', render, {'template_name': 'mapit/privacy.html'}, 'mapit_privacy'),
-    url(r'^docs/', render, {'template_name': 'docs.html'}, 'mapit_docs'),
-    url(r'^admin$', RedirectView.as_view(url='admin/', permanent=True)),
-    url(r'^admin/', admin.site.urls),
-    url(r"^bulk/", include("bulk_lookup.urls")),
-    url(r"^account/api_keys/", include("api_keys.urls")),
-    url(r"^account/subscription", include("subscriptions.urls")),
+    path('changelog', render, {'template_name': 'changelog.html'}, 'mapit_changelog'),
+    path('', include('mapit.urls')),
+    path('contact', render, {'template_name': 'mapit/contact.html'}, 'mapit_contact'),
+    path('pricing/', render, {'template_name': 'pricing.html'}, 'mapit_pricing'),
+    path('legal/', render, {'template_name': 'mapit/licensing.html'}, 'mapit_legal'),
+    path('privacy/', render, {'template_name': 'mapit/privacy.html'}, 'mapit_privacy'),
+    path('docs/', render, {'template_name': 'docs.html'}, 'mapit_docs'),
+    path('admin', RedirectView.as_view(url='admin/', permanent=True)),
+    path('admin/', admin.site.urls),
+    path("bulk/", include("bulk_lookup.urls")),
+    path("account/api_keys/", include("api_keys.urls")),
+    path("account/subscription", include("subscriptions.urls")),
     # Override the login and signup views from the account app, so we can use
     # our versions which use an email address instead of a username.
-    url(r"^account/signup/$", SignupView.as_view(), name="account_signup"),
-    url(r"^account/login/$", LoginView.as_view(), name="account_login"),
-    url(r"^account/logout/$", LogoutView.as_view(), name="account_logout"),
+    path("account/signup/", SignupView.as_view(), name="account_signup"),
+    path("account/login/", LoginView.as_view(), name="account_login"),
+    path("account/logout/", LogoutView.as_view(), name="account_logout"),
     # Override the confirm_email view from the account app, so we can sign
     # people in immediately after they confirm.
-    url(r"^account/confirm_email/(?P<key>\w+)/$", ConfirmEmailView.as_view(), name="account_confirm_email"),
-    url(r"^account/$", RedirectView.as_view(pattern_name='subscription', permanent=True)),
-    url(r"^account/", include("account.urls")),
+    path("account/confirm_email/<key>/", ConfirmEmailView.as_view(), name="account_confirm_email"),
+    path("account/", RedirectView.as_view(pattern_name='subscription', permanent=True)),
+    path("account/", include("account.urls")),
 ]

--- a/mapit_mysociety_org/wsgi_monitor.py
+++ b/mapit_mysociety_org/wsgi_monitor.py
@@ -7,7 +7,7 @@ import sys
 import signal
 import threading
 import atexit
-from six.moves import queue
+import queue
 
 _interval = 1.0
 _times = {}

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -7,6 +7,10 @@ redis==2.10.5
 stripe==2.35.0
 six
 
+Shapely==1.7.1
+PyYAML==5.3.1
+python-memcached==1.59
+
 # Bulk lookup
 xlrd<2
 defusedxml==0.5.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,11 +1,13 @@
 psycopg2 >= 2.5.4
 -e git+https://github.com/mysociety/mapit.git@master#egg=django-mapit
-django-mailer==1.2.2
+django-appconf==1.0.5
+django-formtools==2.3
+django-mailer==2.2
+django-user-accounts==3.2.0
 mock==1.3.0
 mockredispy==2.9.0.12
 redis==2.10.5
 stripe==2.35.0
-six
 
 Shapely==1.7.1
 PyYAML==5.3.1
@@ -13,7 +15,7 @@ python-memcached==1.59
 
 # Bulk lookup
 xlrd<2
-defusedxml==0.5.0
+defusedxml==0.7.1
 pyexcel==0.4.5
 pyexcel-io==0.3.4.1
 pyexcel-odsr==0.3.2

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -14,9 +14,10 @@ PyYAML==5.3.1
 python-memcached==1.59
 
 # Bulk lookup
-xlrd<2
+xlrd==2.0.1
 defusedxml==0.7.1
 pyexcel==0.4.5
 pyexcel-io==0.3.4.1
 pyexcel-odsr==0.3.2
 pyexcel-xls==0.3.3
+pyexcel-xlsx==0.3.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,6 +1,5 @@
 psycopg2 >= 2.5.4
 -e git+https://github.com/mysociety/mapit.git@master#egg=django-mapit
-django-appconf==1.0.3
 django-mailer==1.2.2
 mock==1.3.0
 mockredispy==2.9.0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
-Django==1.11.29
-django-formtools==2.1
-django-user-accounts==2.0.3
-django-appconf==1.0.3
+Django==3.2.13
 -r requirements-base.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django==1.11.29
 django-formtools==2.1
 django-user-accounts==2.0.3
+django-appconf==1.0.3
 -r requirements-base.txt

--- a/subscriptions/models.py
+++ b/subscriptions/models.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.db import models
 from django.dispatch import receiver
 
-from six import python_2_unicode_compatible
 from api_keys.utils import redis_connection
 
 
@@ -15,7 +14,6 @@ def ensure_int(s):
         return 0
 
 
-@python_2_unicode_compatible
 class Subscription(models.Model):
     user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     stripe_id = models.CharField(max_length=100)

--- a/subscriptions/tests.py
+++ b/subscriptions/tests.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import json
-from six import StringIO
+from io import StringIO
 import time
 from mock import patch, Mock
 

--- a/subscriptions/urls.py
+++ b/subscriptions/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path
 from django.contrib.auth.decorators import login_required
 
 from .views import (
@@ -6,33 +6,33 @@ from .views import (
     SubscriptionCardUpdateView, SubscriptionCancelView)
 
 urlpatterns = [
-    url(
-        r'^$',
+    path(
+        '',
         login_required(SubscriptionView.as_view()),
         name="subscription"
     ),
-    url(
-        r'^/invoices$',
+    path(
+        '/invoices',
         login_required(InvoicesView.as_view()),
         name="invoices"
     ),
-    url(
-        r'^/update$',
+    path(
+        '/update',
         login_required(SubscriptionUpdateView.as_view()),
         name="subscription_update"
     ),
-    url(
-        r'^/update-card$',
+    path(
+        '/update-card',
         login_required(SubscriptionCardUpdateView.as_view()),
         name="subscription_card_update"
     ),
-    url(
-        r'^/cancel$',
+    path(
+        '/cancel',
         login_required(SubscriptionCancelView.as_view()),
         name="subscription_cancel"
     ),
-    url(
-        r'^/stripe-hook$',
+    path(
+        '/stripe-hook',
         stripe_hook,
         name="stripe-hook"
     ),

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = flake8, py{27,36}-1.11, py36-{2.2,3.1,3.2}
+envlist = flake8, py27-1.11, py36-{1.11,2.2,3.2}
 
 [testenv]
 commands =
@@ -13,11 +13,12 @@ deps =
     1.11: Django>=1.11,<2.0
     1.11: django-formtools==2.1
     1.11: django-user-accounts==2.0.3
+    1.11: django-appconf==1.0.3
     2.2: Django>=2.2,<3.0
-    3.1: Django>=3.1,<3.2
-    3.2: Django==3.2b1
-    2.2,3.1,3.2: django-formtools==2.2
-    2.2,3.1,3.2: django-user-accounts==3.0.2
+    3.2: Django>=3.2,<4.0
+    2.2,3.2: django-formtools==2.3
+    2.2,3.2: django-user-accounts==3.0.4
+    2.2,3.2: django-appconf==1.0.4
 
 [testenv:flake8]
 skip_install = True
@@ -32,5 +33,4 @@ THING_TO_TEST =
   flake8: flake8
   1.11: 1.11
   2.2: 2.2
-  3.1: 3.1
   3.2: 3.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,36 +1,28 @@
 [tox]
 skipsdist = True
-envlist = flake8, py27-1.11, py36-{1.11,2.2,3.2}
+envlist = flake8, py{37,39}-{2.2,3.2}
 
 [testenv]
 commands =
     flake8: flake8 api_keys bulk_lookup subscriptions mapit_mysociety_org
-    py{27,36}: python -W all -W ignore::PendingDeprecationWarning -m coverage run --source api_keys,bulk_lookup,subscriptions,mapit_mysociety_org manage.py test
+    py{37,39}: python -W all -W ignore::PendingDeprecationWarning -m coverage run --source api_keys,bulk_lookup,subscriptions,mapit_mysociety_org manage.py test
 deps =
-    py{27,36}: coverage
+    py{37,39}: coverage
     flake8: flake8
-    py{27,36}: -r{toxinidir}/requirements-base.txt
-    1.11: Django>=1.11,<2.0
-    1.11: django-formtools==2.1
-    1.11: django-user-accounts==2.0.3
-    1.11: django-appconf==1.0.3
+    py{37,39}: -r{toxinidir}/requirements-base.txt
     2.2: Django>=2.2,<3.0
     3.2: Django>=3.2,<4.0
-    2.2,3.2: django-formtools==2.3
-    2.2,3.2: django-user-accounts==3.0.4
-    2.2,3.2: django-appconf==1.0.4
 
 [testenv:flake8]
 skip_install = True
 
 [gh-actions]
 python =
-    2.7: flake8, py27
-    3.6: flake8, py36
+    3.7: flake8, py37
+    3.9: flake8, py39
 
 [gh-actions:env]
 THING_TO_TEST =
   flake8: flake8
-  1.11: 1.11
   2.2: 2.2
   3.2: 3.2


### PR DESCRIPTION
This adds support for optionally using Redis Sentinel to mediate connections to Redis. ~~In order to test, this extends the GitHub Actions with services for both Redis and Redis Sentinel which are used by the tests when `REDIS_SENTINEL_HOSTS` is set.~~ (not needed, now mocking)

This also includes some updates to get tests passing against Python 3.9 and removes Python 2.7 support from the test suite at the same time as well as Django 1.11.

Currently this also includes commits from #127 rebased against master.

Fixes #132