### PR TITLE
Ensure reset_ip_quotas matches IPv4 and IPv6 addresses

### DIFF
--- a/subscriptions/management/commands/reset_ip_quotas.py
+++ b/subscriptions/management/commands/reset_ip_quotas.py
@@ -9,9 +9,18 @@ class Command(BaseCommand):
 
     def handle(self, **options):
         r = redis_connection()
+        # Clear IPv4 and IPv6 separately due to issues with our test mock handling a glob in the match.
+        # IPv4
         for key in r.scan_iter(match='user:*.*:quota:%s:count' % settings.REDIS_API_NAME, count=100):
             r.delete(key)
             if options['verbosity'] > 1:
                 self.stdout.write("Removed IP %s" % key)
         for key in r.scan_iter(match='user:*.*:quota:%s:blocked' % settings.REDIS_API_NAME, count=100):
+            r.delete(key)
+        # IPv6
+        for key in r.scan_iter(match='user:*:*:quota:%s:count' % settings.REDIS_API_NAME, count=100):
+            r.delete(key)
+            if options['verbosity'] > 1:
+                self.stdout.write("Removed IP %s" % key)
+        for key in r.scan_iter(match='user:*:*:quota:%s:blocked' % settings.REDIS_API_NAME, count=100):
             r.delete(key)

--- a/subscriptions/tests.py
+++ b/subscriptions/tests.py
@@ -569,14 +569,20 @@ class ManagementTest(PatchedRedisTestCase):
         r = redis_connection()
         r.set('user:127.0.0.2:quota:test_api:count', 42)
         r.set('user:127.0.0.3:quota:test_api:blocked', 1)
+        r.set('user:fc00:1::1:quota:test_api:count', 57)
+        r.set('user:fc00:1::1:quota:test_api:blocked', 1)
 
         self.assertEqual(r.get('user:127.0.0.2:quota:test_api:count'), b'42')
         self.assertEqual(r.get('user:127.0.0.3:quota:test_api:blocked'), b'1')
+        self.assertEqual(r.get('user:fc00:1::1:quota:test_api:count'), b'57')
+        self.assertEqual(r.get('user:fc00:1::1:quota:test_api:blocked'), b'1')
 
         call_command('reset_ip_quotas', stdout=StringIO(), stderr=StringIO(), **kwargs)
 
         self.assertIsNone(r.get('user:127.0.0.2:quota:test_api:count'))
         self.assertIsNone(r.get('user:127.0.0.3:quota:test_api:blocked'))
+        self.assertIsNone(r.get('user:fc00:1::1:quota:test_api:count'))
+        self.assertIsNone(r.get('user:fc00:1::1:quota:test_api:blocked'))
 
     def test_reset_ip_quotas(self):
         self._test_reset_ip_quotas()

--- a/subscriptions/tests.py
+++ b/subscriptions/tests.py
@@ -569,7 +569,14 @@ class ManagementTest(PatchedRedisTestCase):
         r = redis_connection()
         r.set('user:127.0.0.2:quota:test_api:count', 42)
         r.set('user:127.0.0.3:quota:test_api:blocked', 1)
+
+        self.assertEqual(r.get('user:127.0.0.2:quota:test_api:count'), b'42')
+        self.assertEqual(r.get('user:127.0.0.3:quota:test_api:blocked'), b'1')
+
         call_command('reset_ip_quotas', stdout=StringIO(), stderr=StringIO(), **kwargs)
+
+        self.assertIsNone(r.get('user:127.0.0.2:quota:test_api:count'))
+        self.assertIsNone(r.get('user:127.0.0.3:quota:test_api:blocked'))
 
     def test_reset_ip_quotas(self):
         self._test_reset_ip_quotas()


### PR DESCRIPTION
This just adapts the glob used so it will catch colons or dots.