### PR TITLE
Bump Django to 3.2.14 and PyYAML to 5.4.1

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -10,7 +10,7 @@ redis==2.10.5
 stripe==2.35.0
 
 Shapely==1.7.1
-PyYAML==5.3.1
+PyYAML==5.4.1
 python-memcached==1.59
 
 # Bulk lookup

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django==3.2.13
+Django==3.2.14
 -r requirements-base.txt


### PR DESCRIPTION
Bump Django due to security release.

See: https://www.djangoproject.com/weblog/2022/jul/04/security-releases/

Bump PyYAML to resolve dependabot alert.