### PR TITLE
Document how the JSON API formats errors

### DIFF
--- a/mapit_mysociety_org/templates/docs.html
+++ b/mapit_mysociety_org/templates/docs.html
@@ -68,8 +68,19 @@
             response headers.
 
             <p>Whenever an area is returned from MapIt, it is as a
-            dictionary with the following keys: id, name, country, type,
-            parent_area, generation_low, generation_high, codes.</p>
+            dictionary with the following keys: <code>id</code>, <code>name</code>,
+            <code>country</code>, <code>type</code>, <code>parent_area</code>,
+            <code>generation_low</code>, <code>generation_high</code>,
+            and <code>codes</code>.</p>
+            </dd>
+
+            <dt>Errors</dt>
+            <dd>
+            Whenever an error is returned from MapIt, it is as a dictionary
+            with an <code>error</code> key (which contains a textual description
+            such as “Postcode […] is not valid.” or “Usage limit reached.”) and
+            an optional <code>code</code> key (which, if present, will be a copy
+            of the HTTP status code).
             </dd>
 
             <dt>Historical areas</dt>


### PR DESCRIPTION
I was working on a project that calls the MapIt API via `jQuery.ajax`, and realised the documentation doesn’t explicitly say how errors are handled, so I had to work it out by trial and error.

Seemed like it’d be a useful thing to include in the docs, so I’ve added a new "Errors" section, right after the "Format" section where we talk about the JSON API format.

While I was there, I also wrapped the JSON object keys in the "Format" section in `<code>` tags, for consistency with how we display HTTP Header fields and query params.

![Screenshot 2023-11-22 at 14 40 11](https://github.com/mysociety/mapit.mysociety.org/assets/739624/82afeae8-aca1-4011-b693-bb038149ff15)
